### PR TITLE
Feat/implement AgentLeads UI and AgentProfile pages

### DIFF
--- a/src/pages/agent/AgentLeads.jsx
+++ b/src/pages/agent/AgentLeads.jsx
@@ -1,0 +1,727 @@
+import { useState, useEffect, useCallback, useContext } from "react";
+import MainLayout from "../../components/layout/Layout";
+import api from "../../api/axios";
+import { AuthContext } from "../../context/AuthProvider";
+
+// NDRYSHIM: shtuar DECLINED në statuset e listës
+const LEAD_STATUSES = ["NEW", "IN_PROGRESS", "DONE", "REJECTED"];
+
+// NDRYSHIM: shtuar stili për DECLINED
+const STATUS_STYLE = {
+  NEW:         { bg: "#eff6ff", color: "#2563eb",  label: "New" },
+  IN_PROGRESS: { bg: "#f5f3ff", color: "#7c3aed",  label: "In Progress" },
+  DONE:        { bg: "#ecfdf5", color: "#059669",  label: "Done" },
+  REJECTED:    { bg: "#fef2f2", color: "#dc2626",  label: "Rejected" },
+  DECLINED:    { bg: "#fff7ed", color: "#ea580c",  label: "Declined" }, // shtuar
+};
+
+const TYPE_ICON   = { SELL: "🏷️", BUY: "🏠", RENT: "🔑", VALUATION: "📊" };
+const SOURCE_ICON = { WEBSITE: "🌐", PHONE: "📞", EMAIL: "✉️", REFERRAL: "👥", SOCIAL: "📱" };
+
+const fmtDate     = (d) => d ? new Date(d).toLocaleDateString("sq-AL") : "—";
+const fmtDateTime = (d) => d ? new Date(d).toLocaleString("sq-AL", {
+  day: "2-digit", month: "2-digit", year: "numeric",
+  hour: "2-digit", minute: "2-digit",
+}) : "—";
+const fmtBudget = (v) => v != null ? `€${Number(v).toLocaleString("de-DE")}` : "—";
+
+// ─── Shared UI ────────────────────────────────────────────────────────────────
+
+function Toast({ msg, type = "success", onDone }) {
+  useEffect(() => {
+    const t = setTimeout(onDone, 3200);
+    return () => clearTimeout(t);
+  }, [onDone]);
+  return (
+    <div style={{
+      position: "fixed", bottom: 28, right: 28, zIndex: 9999,
+      background: type === "error" ? "#fee2e2" : "#ecfdf5",
+      color: type === "error" ? "#b91c1c" : "#047857",
+      padding: "12px 20px", borderRadius: 10, fontSize: 13.5, fontWeight: 500,
+      boxShadow: "0 4px 18px rgba(0,0,0,0.12)", maxWidth: 340,
+      animation: "fadeUp .25s ease",
+    }}>{msg}</div>
+  );
+}
+
+function Loader() {
+  return (
+    <div style={{ textAlign: "center", padding: "60px 0" }}>
+      <div style={{
+        width: 32, height: 32, margin: "0 auto",
+        border: "3px solid #e8edf4", borderTop: "3px solid #6366f1",
+        borderRadius: "50%", animation: "spin 0.7s linear infinite",
+      }} />
+    </div>
+  );
+}
+
+function EmptyState({ icon, text, subtext }) {
+  return (
+    <div style={{ textAlign: "center", padding: "60px 20px", color: "#94a3b8" }}>
+      <div style={{ fontSize: 40, marginBottom: 12 }}>{icon}</div>
+      <p style={{ fontSize: 15, fontWeight: 500, color: "#64748b", marginBottom: 4 }}>{text}</p>
+      {subtext && <p style={{ fontSize: 13 }}>{subtext}</p>}
+    </div>
+  );
+}
+
+function StatusBadge({ status }) {
+  const s = STATUS_STYLE[status] || { bg: "#f1f5f9", color: "#475569", label: status };
+  return (
+    <span style={{
+      background: s.bg, color: s.color, padding: "3px 10px", borderRadius: 20,
+      fontSize: 11.5, fontWeight: 600,
+      display: "inline-flex", alignItems: "center", gap: 5,
+    }}>
+      <span style={{ width: 6, height: 6, borderRadius: "50%",
+        background: s.color, display: "inline-block" }} />
+      {s.label}
+    </span>
+  );
+}
+
+function Pagination({ page, totalPages, onChange }) {
+  if (totalPages <= 1) return null;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6,
+      justifyContent: "flex-end", padding: "14px 16px" }}>
+      <button className="btn btn--secondary btn--sm"
+        disabled={page === 0} onClick={() => onChange(page - 1)}>← Prev</button>
+      <span style={{ fontSize: 13, color: "#64748b", padding: "0 8px" }}>
+        {page + 1} / {totalPages}
+      </span>
+      <button className="btn btn--secondary btn--sm"
+        disabled={page >= totalPages - 1} onClick={() => onChange(page + 1)}>Next →</button>
+    </div>
+  );
+}
+
+// ─── NDRYSHIM: StatusActions ──────────────────────────────────────────────────
+// Para: kishte Accept + Reject për NEW, Complete + Reject për IN_PROGRESS
+//       Por shfaqej edhe në All Leads / By Property (gabim)
+// Tani: isMyLead kontrollon ku shfaqen butonat
+//       NEW (My Leads):         Accept + Decline (jo Reject)
+//       IN_PROGRESS (My Leads): Complete + Reject
+//       All Leads / By Property: asnjë buton veprimi
+
+function StatusActions({ lead, onStatusChange, onDecline, loading, isMyLead }) {
+  const { status } = lead;
+
+  // DONE dhe REJECTED: finale absolute — asnjë buton
+  if (status === "DONE" || status === "REJECTED") {
+    return <span style={{ fontSize: 12, color: "#94a3b8", fontStyle: "italic" }}>Final</span>;
+  }
+
+  // All Leads / By Property: vetëm info, pa buton veprimi
+  // NDRYSHIM: hequr butonat nga kjo pamje — isMyLead = false
+  if (!isMyLead) {
+  // Dallo: NEW pa agjent vs NEW me agjent (pret pranimin)
+  if (status === "NEW" && !lead.assigned_agent_id) {
+    return (
+      <span style={{
+        fontSize: 11.5, color: "#64748b", background: "#f1f5f9",
+        padding: "3px 10px", borderRadius: 20,
+      }}>
+        🕐 Pa asignuar
+      </span>
+    );
+  }
+  if (status === "NEW" && lead.assigned_agent_id) {
+    return (
+      <span style={{
+        fontSize: 11.5, color: "#d97706", background: "#fffbeb",
+        padding: "3px 10px", borderRadius: 20,
+      }}>
+        ⏳ Pret pranimin
+      </span>
+    );
+  }
+  // IN_PROGRESS, DONE, REJECTED — vetëm shiko
+  return (
+    <span style={{
+      fontSize: 11.5, color: "#94a3b8", background: "#f1f5f9",
+      padding: "3px 10px", borderRadius: 20, fontStyle: "italic",
+    }}>
+      Vetëm shiko
+    </span>
+  );
+}
+
+  // My Leads — NEW: Accept + Decline
+  // NDRYSHIM: shtohet Decline, hiqet Reject nga NEW
+  // Logjika: nëse agjenti nuk dëshiron ta marrë, klikon Decline (operacional)
+  //          Reject është vetëm pas pranimit (IN_PROGRESS) — vendim biznesi
+  if (status === "NEW") {
+    return (
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        <button
+          className="btn btn--primary btn--sm"
+          onClick={() => onStatusChange(lead.id, "IN_PROGRESS")}
+          disabled={loading}
+          title="Prano lead-in dhe fillo punën"
+        >
+          ▶ Accept
+        </button>
+        {/* SHTUAR: Decline — kthen lead tek admini si NEW pa agjent */}
+        <button
+          className="btn btn--secondary btn--sm"
+          onClick={() => onDecline(lead.id)}
+          disabled={loading}
+          title="Nuk mund ta trajtosh? Kthehet tek admini për reassignment"
+          style={{ color: "#ea580c", borderColor: "#fed7aa" }}
+        >
+          ↩ Decline
+        </button>
+      </div>
+    );
+  }
+
+  // My Leads — IN_PROGRESS: Complete + Reject
+  // NDRYSHIM: Reject mbetet vetëm këtu (pas pranimit — vendim final biznesi)
+  if (status === "IN_PROGRESS") {
+    return (
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        <button
+          className="btn btn--sm"
+          style={{ background: "#ecfdf5", color: "#059669", border: "1px solid #a7f3d0" }}
+          onClick={() => onStatusChange(lead.id, "DONE")}
+          disabled={loading}
+        >
+          ✓ Complete
+        </button>
+        <button
+          className="btn btn--danger btn--sm"
+          onClick={() => onStatusChange(lead.id, "REJECTED")}
+          disabled={loading}
+          title="Refuzo definitivisht — vendim final biznesi"
+        >
+          ✕ Reject
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ─── Lead Detail Modal ────────────────────────────────────────────────────────
+// NDRYSHIM: shtohet onDecline prop dhe banner informues sipas statusit
+
+function LeadDetailModal({ lead, onClose, onStatusChange, onDecline, statusLoading, isMyLead }) {
+  const { user } = useContext(AuthContext); 
+  useEffect(() => {
+    const h = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [onClose]);
+
+  return (
+    <div style={{
+      position: "fixed", inset: 0, zIndex: 1000,
+      background: "rgba(15,23,42,0.45)",
+      display: "flex", alignItems: "center", justifyContent: "center", padding: 20,
+    }} onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div style={{
+        width: "100%", maxWidth: 580, background: "#fff",
+        borderRadius: 16, boxShadow: "0 20px 60px rgba(15,23,42,0.18)",
+        maxHeight: "90vh", overflowY: "auto", animation: "fadeUp .2s ease",
+      }}>
+        {/* Header */}
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "18px 24px", borderBottom: "1px solid #e8edf4",
+        }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <span style={{ fontSize: 22 }}>{TYPE_ICON[lead.type] || "📋"}</span>
+            <div>
+              <h3 style={{ fontWeight: 600, fontSize: 15, margin: 0 }}>
+                Lead #{lead.id} — {lead.type}
+              </h3>
+              <p style={{ fontSize: 12, color: "#64748b", margin: 0 }}>
+                Krijuar: {fmtDateTime(lead.created_at)}
+              </p>
+            </div>
+          </div>
+          <button onClick={onClose} style={{
+            width: 30, height: 30, border: "none", background: "none",
+            color: "#94a3b8", cursor: "pointer", fontSize: 16, borderRadius: 6,
+          }}>✕</button>
+        </div>
+
+        <div style={{ padding: "22px 24px" }}>
+
+          {/* NDRYSHIM: banner informues sipas kontekstit */}
+          {!isMyLead && (
+            <div style={{
+              background: "#fffbeb", border: "1px solid #fde68a",
+              borderRadius: 8, padding: "10px 14px", marginBottom: 18,
+              fontSize: 13, color: "#92400e", display: "flex", alignItems: "center", gap: 8,
+            }}>
+              <span>ℹ️</span>
+              <span>
+                {!lead.assigned_agent_id
+                  ? "Ky lead nuk i është asignuar ende asnjë agjenti."
+                  : lead.assigned_agent_id === user?.id
+                    ? "Ky lead ju është asignuar juve."           // ← ID e juaja
+                    : `Ky lead i është asignuar agjentit #${lead.assigned_agent_id}.`}
+              </span>
+            </div>
+          )}
+
+          {/* Status + actions */}
+          <div style={{
+            display: "flex", alignItems: "center", justifyContent: "space-between",
+            marginBottom: 20, padding: "12px 16px",
+            background: "#f8fafc", borderRadius: 10, border: "1px solid #e8edf4",
+          }}>
+            <div>
+              <p style={{ fontSize: 11, color: "#94a3b8", fontWeight: 600,
+                textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 5 }}>
+                Statusi
+              </p>
+              <StatusBadge status={lead.status} />
+            </div>
+            {/* NDRYSHIM: passo onDecline */}
+            <StatusActions
+              lead={lead}
+              onStatusChange={onStatusChange}
+              onDecline={onDecline}
+              loading={statusLoading}
+              isMyLead={isMyLead}
+            />
+          </div>
+
+          {/* Info grid */}
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14, marginBottom: 18 }}>
+            {[
+              { label: "Client ID",      value: `#${lead.client_id}` },
+              { label: "Property ID",    value: lead.property_id ? `#${lead.property_id}` : "—" },
+              { label: "Tipi",           value: `${TYPE_ICON[lead.type] || ""} ${lead.type}` },
+              { label: "Burimi",         value: `${SOURCE_ICON[lead.source] || ""} ${lead.source}` },
+              { label: "Buxheti",        value: fmtBudget(lead.budget) },
+              { label: "Data preferuar", value: fmtDate(lead.preferred_date) },
+              { label: "Agjent assigned", value: lead.assigned_agent_id ? `#${lead.assigned_agent_id}` : "—" },
+              { label: "Ndryshuar më",   value: fmtDateTime(lead.updated_at) },
+            ].map(({ label, value }) => (
+              <div key={label} style={{
+                background: "#f8fafc", borderRadius: 8, padding: "10px 14px",
+                border: "1px solid #e8edf4",
+              }}>
+                <p style={{ fontSize: 11, color: "#94a3b8", fontWeight: 600,
+                  textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 4 }}>
+                  {label}
+                </p>
+                <p style={{ fontSize: 13.5, fontWeight: 500, color: "#0f172a" }}>{value}</p>
+              </div>
+            ))}
+          </div>
+
+          {lead.message && (
+            <div style={{
+              background: "#f8fafc", border: "1px solid #e8edf4",
+              borderRadius: 10, padding: "14px 16px",
+            }}>
+              <p style={{ fontSize: 11, color: "#94a3b8", fontWeight: 600,
+                textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 8 }}>
+                Mesazhi
+              </p>
+              <p style={{ fontSize: 13.5, color: "#374151", lineHeight: 1.6 }}>
+                {lead.message}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Lead Row ─────────────────────────────────────────────────────────────────
+// NDRYSHIM: shtohet onDecline dhe isMyLead prop
+
+function LeadRow({ lead, onView, onStatusChange, onDecline, statusLoading, isMyLead }) {
+  return (
+    <tr>
+      <td style={{ color: "#94a3b8", fontSize: 12 }}>{lead.id}</td>
+      <td>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: 16 }}>{TYPE_ICON[lead.type] || "📋"}</span>
+          <span style={{ fontWeight: 500, fontSize: 13.5 }}>{lead.type}</span>
+        </div>
+      </td>
+      <td>
+        <span style={{ background: "#eef2ff", color: "#6366f1",
+          padding: "2px 8px", borderRadius: 20, fontSize: 12, fontWeight: 500 }}>
+          #{lead.client_id}
+        </span>
+      </td>
+      <td>
+        {lead.property_id
+          ? <span style={{ background: "#f0f9ff", color: "#0ea5e9",
+              padding: "2px 8px", borderRadius: 20, fontSize: 12, fontWeight: 500 }}>
+              #{lead.property_id}
+            </span>
+          : <span style={{ color: "#94a3b8", fontSize: 12 }}>—</span>}
+      </td>
+      {/* NDRYSHIM: shfaq kolonën "Agjenti" vetëm jashtë My Leads */}
+      {!isMyLead && (
+        <td>
+          {lead.assigned_agent_id
+            ? <span style={{ background: "#f0fdf4", color: "#166534",
+                padding: "2px 8px", borderRadius: 20, fontSize: 12, fontWeight: 500 }}>
+                #{lead.assigned_agent_id}
+              </span>
+            : <span style={{ color: "#94a3b8", fontSize: 12, fontStyle: "italic" }}>
+                Pa agjent
+              </span>}
+        </td>
+      )}
+      <td style={{ fontSize: 12.5, color: "#64748b" }}>
+        {SOURCE_ICON[lead.source]} {lead.source}
+      </td>
+      <td style={{ fontWeight: 600, fontSize: 13 }}>{fmtBudget(lead.budget)}</td>
+      <td><StatusBadge status={lead.status} /></td>
+      <td style={{ fontSize: 12, color: "#94a3b8" }}>{fmtDate(lead.created_at)}</td>
+      <td>
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <button className="btn btn--ghost btn--sm" onClick={() => onView(lead)}>
+            View
+          </button>
+          {/* NDRYSHIM: passo onDecline dhe isMyLead */}
+          <StatusActions
+            lead={lead}
+            onStatusChange={onStatusChange}
+            onDecline={onDecline}
+            loading={statusLoading}
+            isMyLead={isMyLead}
+          />
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MAIN PAGE
+// ═══════════════════════════════════════════════════════════════════════════════
+export default function AgentLeads() {
+  const [activeTab, setActiveTab] = useState("my");
+  const [leads, setLeads] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [statusLoading, setStatusLoading] = useState(false);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [statusFilter, setStatusFilter] = useState("NEW");
+  const [propertyId, setPropertyId] = useState("");
+  const [selectedLead, setSelectedLead] = useState(null);
+  const [toast, setToast] = useState(null);
+
+  // NDRYSHIM: stats — shtuar declined, hequr "new" (normalisht 0 në My Leads)
+  const [stats, setStats] = useState({ new: 0, inProgress: 0, done: 0, rejected: 0 });
+
+  const notify = useCallback((msg, type = "success") =>
+    setToast({ msg, type, key: Date.now() }), []);
+
+  const fetchLeads = useCallback(async () => {
+    setLoading(true);
+    try {
+      let url;
+      if (activeTab === "my") {
+        url = `/api/leads/my/agent?page=${page}&size=15`;
+      } else if (activeTab === "all") {
+        url = `/api/leads?status=${statusFilter}&page=${page}&size=15`;
+      } else {
+        setLoading(false);
+        return;
+      }
+      const res  = await api.get(url);
+      const data = res.data;
+      if (data.content !== undefined) {
+        setLeads(data.content || []);
+        setTotalPages(data.totalPages || 0);
+      } else {
+        setLeads(Array.isArray(data) ? data : []);
+        setTotalPages(1);
+      }
+    } catch {
+      notify("Gabim gjatë ngarkimit të leads", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [activeTab, page, statusFilter, notify]);
+
+  useEffect(() => {
+    if (activeTab !== "property") fetchLeads();
+  }, [fetchLeads, activeTab]);
+
+  useEffect(() => {
+    if (activeTab === "my") {
+      setStats({
+        new:        leads.filter((l) => l.status === "NEW").length,
+        inProgress: leads.filter((l) => l.status === "IN_PROGRESS").length,
+        done:       leads.filter((l) => l.status === "DONE").length,
+        rejected:   leads.filter((l) => l.status === "REJECTED").length,
+      });
+    }
+  }, [leads, activeTab]);
+
+  const fetchByProperty = async () => {
+    if (!propertyId) { notify("Shkruaj Property ID", "error"); return; }
+    setLoading(true);
+    try {
+      const res = await api.get(`/api/leads/property/${propertyId}`);
+      setLeads(Array.isArray(res.data) ? res.data : []);
+      setTotalPages(1);
+    } catch {
+      notify("Gabim ose prona nuk u gjet", "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // ── pa ndryshim ───────────────────────────────────────────────────────────
+  const handleStatusChange = async (id, newStatus) => {
+    setStatusLoading(true);
+    try {
+      await api.patch(`/api/leads/${id}/status`, { status: newStatus });
+      notify(`Lead #${id} → ${newStatus}`);
+      setLeads((prev) => prev.map((l) => l.id === id ? { ...l, status: newStatus } : l));
+      if (selectedLead?.id === id) {
+        setSelectedLead((prev) => ({ ...prev, status: newStatus }));
+      }
+    } catch (err) {
+      notify(err.response?.data?.message || "Gabim gjatë ndryshimit të statusit", "error");
+    } finally {
+      setStatusLoading(false);
+    }
+  };
+
+  // SHTUAR: handleDecline — thërret PATCH /api/leads/{id}/decline
+  const handleDecline = async (id) => {
+    setStatusLoading(true);
+    try {
+      await api.patch(`/api/leads/${id}/decline`);
+      notify(`Lead #${id} u kthye tek admini — do të asinohet tek agjent tjetër`);
+      // Largo nga lista My Leads — tani nuk i takon këtij agjenti
+      setLeads((prev) => prev.filter((l) => l.id !== id));
+      if (selectedLead?.id === id) setSelectedLead(null);
+    } catch (err) {
+      notify(err.response?.data?.message || "Gabim gjatë decline", "error");
+    } finally {
+      setStatusLoading(false);
+    }
+  };
+
+  const handleTabChange = (tab) => {
+    setActiveTab(tab);
+    setPage(0);
+    setLeads([]);
+  };
+
+  const isMyLeadsTab = activeTab === "my";
+
+  // NDRYSHIM: stat cards — shtuar "New" sepse tani agjenti mund të ketë NEW në My Leads
+  const statCards = [
+    { label: "New",         value: stats.new,        color: "#2563eb", bg: "#eff6ff" },
+    { label: "In Progress", value: stats.inProgress,  color: "#7c3aed", bg: "#f5f3ff" },
+    { label: "Done",        value: stats.done,        color: "#059669", bg: "#ecfdf5" },
+    { label: "Rejected",    value: stats.rejected,    color: "#dc2626", bg: "#fef2f2" },
+  ];
+
+  return (
+    <MainLayout role="agent">
+      <style>{`
+        @keyframes fadeUp { from{opacity:0;transform:translateY(8px);} to{opacity:1;transform:translateY(0);} }
+        @keyframes spin { to { transform: rotate(360deg); } }
+      `}</style>
+
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">Leads Management</h1>
+          <p className="page-subtitle">Menaxho kërkesat e klientëve dhe gjurmo progresin</p>
+        </div>
+      </div>
+
+      {isMyLeadsTab && (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 14, marginBottom: 24 }}>
+          {statCards.map((s) => (
+            <div key={s.label} className="stat-card">
+              <div className="stat-card__label">{s.label}</div>
+              <div className="stat-card__value" style={{ color: s.color }}>{s.value}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* NDRYSHIM: flow guide i përditësuar me Decline */}
+      <div style={{
+        display: "flex", alignItems: "center", gap: 6,
+        marginBottom: 20, padding: "11px 16px",
+        background: isMyLeadsTab ? "#f0fdf4" : "#f0f4ff",
+        borderRadius: 10,
+        border: `1px solid ${isMyLeadsTab ? "#bbf7d0" : "#c7d7fe"}`,
+        fontSize: 13, flexWrap: "wrap",
+      }}>
+        {isMyLeadsTab ? (
+          <>
+            <span>🔵 NEW</span>
+            <span style={{ color: "#94a3b8" }}>→</span>
+            <span style={{ color: "#6366f1", fontWeight: 600 }}>▶ Accept</span>
+            <span style={{ color: "#94a3b8" }}>→</span>
+            <span>🟣 IN_PROGRESS</span>
+            <span style={{ color: "#94a3b8" }}>→</span>
+            <span style={{ color: "#059669", fontWeight: 600 }}>✓ Complete</span>
+            <span style={{ color: "#94a3b8" }}>→</span>
+            <span>🟢 DONE</span>
+            <span style={{ color: "#94a3b8", margin: "0 4px" }}>|</span>
+            {/* SHTUAR: Decline në flow guide */}
+            <span style={{ color: "#ea580c", fontWeight: 600 }}>↩ Decline</span>
+            <span style={{ color: "#94a3b8" }}>→ kthehet tek admini</span>
+            <span style={{ color: "#94a3b8", margin: "0 4px" }}>|</span>
+            <span style={{ color: "#dc2626", fontWeight: 600 }}>✕ Reject</span>
+            <span style={{ color: "#94a3b8" }}>→ 🔴 REJECTED (final)</span>
+          </>
+        ) : (
+          <>
+            <span>ℹ️</span>
+            <span style={{ color: "#3730a3" }}>
+              Leads <strong>NEW</strong> presin asignimin nga admini.
+              Menaxho leads të tuat nga tab-i <strong>My Leads</strong>.
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Tabs + filters */}
+      <div style={{ display: "flex", alignItems: "center",
+        justifyContent: "space-between", marginBottom: 16, flexWrap: "wrap", gap: 10 }}>
+        <div style={{ display: "flex", gap: 4, borderBottom: "1px solid #e8edf4", paddingBottom: 0 }}>
+          {[
+            { id: "my",       label: "My Leads",    icon: "👤" },
+            { id: "all",      label: "All Leads",   icon: "📋" },
+            { id: "property", label: "By Property", icon: "🏠" },
+          ].map((t) => (
+            <button key={t.id} onClick={() => handleTabChange(t.id)} style={{
+              padding: "9px 16px", border: "none",
+              borderBottom: activeTab === t.id ? "2px solid #6366f1" : "2px solid transparent",
+              background: "none",
+              color: activeTab === t.id ? "#6366f1" : "#64748b",
+              fontWeight: activeTab === t.id ? 600 : 400,
+              fontSize: 13.5, cursor: "pointer", fontFamily: "inherit",
+              marginBottom: -1, display: "flex", alignItems: "center", gap: 5,
+            }}>
+              {t.icon} {t.label}
+            </button>
+          ))}
+        </div>
+
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          {activeTab === "all" && (
+            <select className="form-select"
+              style={{ height: 34, padding: "0 10px", fontSize: 13, width: 160 }}
+              value={statusFilter}
+              onChange={(e) => { setStatusFilter(e.target.value); setPage(0); }}>
+              {/* NDRYSHIM: shtuar DECLINED në dropdown */}
+              {LEAD_STATUSES.map((s) => <option key={s} value={s}>{s}</option>)}
+            </select>
+          )}
+          {activeTab === "property" && (
+            <>
+              <input className="form-input"
+                style={{ height: 34, padding: "0 10px", fontSize: 13, width: 130 }}
+                type="number" placeholder="Property ID..."
+                value={propertyId}
+                onChange={(e) => setPropertyId(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && fetchByProperty()} />
+              <button className="btn btn--primary btn--sm" onClick={fetchByProperty}>
+                Search
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="card">
+        <div className="card__header">
+          <h2 className="card__title">
+            {activeTab === "my"       ? "My Assigned Leads" : ""}
+            {activeTab === "all"      ? `All Leads — ${statusFilter}` : ""}
+            {activeTab === "property" ? "Leads by Property" : ""}
+          </h2>
+          {leads.length > 0 && (
+            <span style={{ background: "#eef2ff", color: "#6366f1",
+              padding: "3px 10px", borderRadius: 20, fontSize: 12, fontWeight: 500 }}>
+              {leads.length} leads
+            </span>
+          )}
+        </div>
+
+        {loading ? <Loader /> : leads.length === 0 ? (
+          <EmptyState
+            icon={activeTab === "property" ? "🔍" : "📭"}
+            text={activeTab === "property"
+              ? "Shkruaj Property ID dhe kliko Search"
+              : "Nuk ka leads në këtë kategori"}
+            subtext={activeTab === "my"
+              ? "Leads do të shfaqen kur admini t'i asignojë tek ju"
+              : undefined}
+          />
+        ) : (
+          <>
+            <div className="table-wrap">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th>Tipi</th>
+                    <th>Client</th>
+                    <th>Property</th>
+                    {/* NDRYSHIM: kolona Agjenti vetëm jashtë My Leads */}
+                    {!isMyLeadsTab && <th>Agjenti</th>}
+                    <th>Burimi</th>
+                    <th>Buxheti</th>
+                    <th>Statusi</th>
+                    <th>Krijuar</th>
+                    <th>Veprime</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {leads.map((lead) => (
+                    <LeadRow
+                      key={lead.id}
+                      lead={lead}
+                      onView={setSelectedLead}
+                      onStatusChange={handleStatusChange}
+                      onDecline={handleDecline}       // SHTUAR
+                      statusLoading={statusLoading}
+                      isMyLead={isMyLeadsTab}         // SHTUAR
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <Pagination page={page} totalPages={totalPages} onChange={setPage} />
+          </>
+        )}
+      </div>
+
+      {selectedLead && (
+        <LeadDetailModal
+          lead={selectedLead}
+          onClose={() => setSelectedLead(null)}
+          onStatusChange={handleStatusChange}
+          onDecline={handleDecline}             // SHTUAR
+          statusLoading={statusLoading}
+          isMyLead={isMyLeadsTab}               // SHTUAR
+        />
+      )}
+
+      {toast && (
+        <Toast key={toast.key} msg={toast.msg} type={toast.type}
+          onDone={() => setToast(null)} />
+      )}
+    </MainLayout>
+  );
+}

--- a/src/pages/agent/AgentProfile.jsx
+++ b/src/pages/agent/AgentProfile.jsx
@@ -1,0 +1,488 @@
+import { useState, useEffect, useContext } from "react";
+import MainLayout from "../../components/layout/Layout";
+import { AuthContext } from "../../context/AuthProvider";
+import api from "../../api/axios";
+
+// ─── Toast ────────────────────────────────────────────────────────────────────
+function Toast({ msg, type = "success", onDone }) {
+  useEffect(() => {
+    const t = setTimeout(onDone, 3200);
+    return () => clearTimeout(t);
+  }, [onDone]);
+  return (
+    <div style={{
+      position: "fixed", bottom: 28, right: 28, zIndex: 9999,
+      background: type === "error" ? "#fee2e2" : "#ecfdf5",
+      color: type === "error" ? "#b91c1c" : "#047857",
+      padding: "12px 20px", borderRadius: 10, fontSize: 13.5, fontWeight: 500,
+      boxShadow: "0 4px 18px rgba(0,0,0,0.12)", maxWidth: 340,
+      animation: "fadeUp .25s ease",
+    }}>
+      {msg}
+    </div>
+  );
+}
+
+// ─── Field ────────────────────────────────────────────────────────────────────
+function Field({ label, children, required }) {
+  return (
+    <div className="form-group">
+      <label className="form-label">
+        {label}{required && <span style={{ color: "#ef4444", marginLeft: 2 }}>*</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+// ─── Stars ────────────────────────────────────────────────────────────────────
+function StarRating({ value = 0 }) {
+  const stars = Math.round(Number(value) * 2) / 2;
+  return (
+    <div style={{ display: "flex", gap: 2, alignItems: "center" }}>
+      {[1, 2, 3, 4, 5].map((s) => (
+        <svg key={s} width="16" height="16" viewBox="0 0 24 24"
+          fill={s <= stars ? "#f59e0b" : "#e2e8f0"}
+          stroke={s <= stars ? "#f59e0b" : "#cbd5e1"}
+          strokeWidth="1.5">
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        </svg>
+      ))}
+      <span style={{ fontSize: 13, color: "#64748b", marginLeft: 4 }}>
+        {Number(value).toFixed(1)}
+      </span>
+    </div>
+  );
+}
+
+// ─── Avatar ───────────────────────────────────────────────────────────────────
+function Avatar({ photoUrl, name, size = 80 }) {
+  const initials = name
+    ? name.trim().split(" ").slice(0, 2).map(w => w[0]?.toUpperCase()).join("")
+    : "AG";
+  if (photoUrl) {
+    return (
+      <img src={photoUrl} alt={name}
+        style={{ width: size, height: size, borderRadius: "50%", objectFit: "cover",
+          border: "3px solid #eef2ff" }} />
+    );
+  }
+  return (
+    <div style={{
+      width: size, height: size, borderRadius: "50%",
+      background: "linear-gradient(135deg, #6366f1, #818cf8)",
+      display: "flex", alignItems: "center", justifyContent: "center",
+      color: "white", fontSize: size * 0.32, fontWeight: 600,
+      border: "3px solid #eef2ff", flexShrink: 0,
+    }}>
+      {initials}
+    </div>
+  );
+}
+
+// ─── Loader ───────────────────────────────────────────────────────────────────
+function Loader() {
+  return (
+    <div style={{ textAlign: "center", padding: "60px 0" }}>
+      <div style={{
+        width: 32, height: 32, margin: "0 auto",
+        border: "3px solid #e8edf4", borderTop: "3px solid #6366f1",
+        borderRadius: "50%", animation: "spin 0.7s linear infinite",
+      }} />
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MAIN PAGE
+// ═══════════════════════════════════════════════════════════════════════════════
+export default function AgentProfile() {
+  const { user } = useContext(AuthContext);
+  const [profile, setProfile] = useState(null);
+  const [userInfo, setUserInfo] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [savingUser, setSavingUser] = useState(false);
+  const [activeTab, setActiveTab] = useState("profile");
+  const [toast, setToast] = useState(null);
+
+  // Form states
+  const [profileForm, setProfileForm] = useState({
+    phone: "", license: "", bio: "",
+    experience_years: "", specialization: "", photo_url: "",
+  });
+  const [userForm, setUserForm] = useState({
+    first_name: "", last_name: "", email: "",
+  });
+  const [pwForm, setPwForm] = useState({
+    current_password: "", new_password: "", confirm: "",
+  });
+  const [savingPw, setSavingPw] = useState(false);
+
+  const notify = (msg, type = "success") =>
+    setToast({ msg, type, key: Date.now() });
+
+  // ── Fetch ────────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      try {
+        const [meRes, profileRes] = await Promise.all([
+          api.get("/api/users/me"),
+          api.get("/api/users/agents/me").catch(() => ({ data: null })),
+        ]);
+        setUserInfo(meRes.data);
+        setUserForm({
+          first_name: meRes.data.first_name || "",
+          last_name:  meRes.data.last_name  || "",
+          email:      meRes.data.email      || "",
+        });
+        if (profileRes.data) {
+          setProfile(profileRes.data);
+          setProfileForm({
+            phone:            profileRes.data.phone            || "",
+            license:          profileRes.data.license          || "",
+            bio:              profileRes.data.bio              || "",
+            experience_years: profileRes.data.experience_years || "",
+            specialization:   profileRes.data.specialization   || "",
+            photo_url:        profileRes.data.photo_url        || "",
+          });
+        }
+      } catch {
+        notify("Gabim gjatë ngarkimit të profilit", "error");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  // ── Save agent profile ────────────────────────────────────────────────────────
+  const handleSaveProfile = async () => {
+    setSaving(true);
+    try {
+      const payload = {
+        phone:            profileForm.phone            || null,
+        license:          profileForm.license          || null,
+        bio:              profileForm.bio              || null,
+        experience_years: profileForm.experience_years
+          ? Number(profileForm.experience_years) : null,
+        specialization:   profileForm.specialization   || null,
+        photo_url:        profileForm.photo_url        || null,
+      };
+      const res = await api.put("/api/users/agents/me", payload);
+      setProfile(res.data);
+      notify("Profili u ruajt me sukses");
+    } catch (err) {
+      notify(err.response?.data?.message || "Gabim gjatë ruajtjes", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── Save user info ────────────────────────────────────────────────────────────
+  const handleSaveUser = async () => {
+    setSavingUser(true);
+    try {
+      const res = await api.put("/api/users/me", {
+        first_name: userForm.first_name || null,
+        last_name:  userForm.last_name  || null,
+        email:      userForm.email      || null,
+      });
+      setUserInfo(res.data);
+      notify("Të dhënat u ndryshua me sukses");
+    } catch (err) {
+      notify(err.response?.data?.message || "Gabim gjatë ruajtjes", "error");
+    } finally {
+      setSavingUser(false);
+    }
+  };
+
+  // ── Change password ───────────────────────────────────────────────────────────
+  const handleChangePw = async () => {
+    if (pwForm.new_password !== pwForm.confirm) {
+      notify("Fjalëkalimet nuk përputhen", "error");
+      return;
+    }
+    if (pwForm.new_password.length < 8) {
+      notify("Fjalëkalimi duhet të ketë minimum 8 karaktere", "error");
+      return;
+    }
+    setSavingPw(true);
+    try {
+      await api.patch("/api/users/me/password", {
+        current_password: pwForm.current_password,
+        new_password:     pwForm.new_password,
+      });
+      setPwForm({ current_password: "", new_password: "", confirm: "" });
+      notify("Fjalëkalimi u ndryshua me sukses");
+    } catch (err) {
+      notify(err.response?.data?.message || "Gabim gjatë ndryshimit", "error");
+    } finally {
+      setSavingPw(false);
+    }
+  };
+
+  const setP = (k, v) => setProfileForm(p => ({ ...p, [k]: v }));
+  const setU = (k, v) => setUserForm(p => ({ ...p, [k]: v }));
+  const setPw = (k, v) => setPwForm(p => ({ ...p, [k]: v }));
+
+  const fullName = userInfo
+    ? `${userInfo.first_name || ""} ${userInfo.last_name || ""}`.trim()
+    : user?.fullName || "Agent";
+
+  return (
+    <MainLayout role="agent">
+      <style>{`
+        @keyframes fadeUp { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
+        @keyframes spin { to { transform: rotate(360deg); } }
+      `}</style>
+
+      <div className="page-header">
+        <div>
+          <h1 className="page-title">My Profile</h1>
+          <p className="page-subtitle">Menaxho profilin dhe kredencialet e tua</p>
+        </div>
+      </div>
+
+      {loading ? <Loader /> : (
+        <div style={{ display: "grid", gridTemplateColumns: "280px 1fr", gap: 24, alignItems: "start" }}>
+
+          {/* ── Sidebar card ────────────────────────────────────────────────── */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div className="card">
+              <div style={{ padding: "28px 20px", textAlign: "center" }}>
+                <div style={{ display: "flex", justifyContent: "center", marginBottom: 14 }}>
+                  <Avatar photoUrl={profile?.photo_url} name={fullName} size={88} />
+                </div>
+                <h3 style={{ fontWeight: 600, fontSize: 16, marginBottom: 4 }}>{fullName}</h3>
+                <p style={{ fontSize: 12.5, color: "#64748b", marginBottom: 10 }}>
+                  {userInfo?.email}
+                </p>
+                <span style={{
+                  background: "#eef2ff", color: "#6366f1",
+                  padding: "3px 12px", borderRadius: 20,
+                  fontSize: 11.5, fontWeight: 500,
+                }}>Agent</span>
+
+                {profile && (
+                  <div style={{ marginTop: 18, paddingTop: 18, borderTop: "1px solid #e8edf4" }}>
+                    <div style={{ marginBottom: 10 }}>
+                      <StarRating value={profile.rating || 0} />
+                      <p style={{ fontSize: 11.5, color: "#94a3b8", marginTop: 4 }}>
+                        {profile.total_reviews || 0} vlerësime
+                      </p>
+                    </div>
+                    {profile.specialization && (
+                      <p style={{ fontSize: 12.5, color: "#475569", marginTop: 8 }}>
+                        🎯 {profile.specialization}
+                      </p>
+                    )}
+                    {profile.experience_years != null && (
+                      <p style={{ fontSize: 12.5, color: "#475569", marginTop: 4 }}>
+                        📅 {profile.experience_years} vite përvojë
+                      </p>
+                    )}
+                    {profile.phone && (
+                      <p style={{ fontSize: 12.5, color: "#475569", marginTop: 4 }}>
+                        📞 {profile.phone}
+                      </p>
+                    )}
+                    {profile.license && (
+                      <p style={{ fontSize: 12.5, color: "#475569", marginTop: 4 }}>
+                        📋 {profile.license}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {!profile && (
+                  <div style={{
+                    marginTop: 16, padding: "10px 14px",
+                    background: "#fffbeb", border: "1px solid #fde68a",
+                    borderRadius: 8, fontSize: 12.5, color: "#92400e",
+                  }}>
+                    Profili i agjentit nuk është krijuar. Plotëso formularin.
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Nav tabs */}
+            <div className="card" style={{ overflow: "hidden" }}>
+              {[
+                { id: "profile", label: "Profili i Agjentit", icon: "👤" },
+                { id: "account", label: "Llogaria", icon: "✉️" },
+                { id: "password", label: "Fjalëkalimi", icon: "🔒" },
+              ].map(tab => (
+                <button key={tab.id} onClick={() => setActiveTab(tab.id)}
+                  style={{
+                    width: "100%", display: "flex", alignItems: "center", gap: 10,
+                    padding: "11px 16px", border: "none", background: "none",
+                    borderLeft: activeTab === tab.id ? "3px solid #6366f1" : "3px solid transparent",
+                    color: activeTab === tab.id ? "#6366f1" : "#475569",
+                    fontWeight: activeTab === tab.id ? 600 : 400,
+                    fontSize: 13.5, cursor: "pointer", fontFamily: "inherit",
+                    textAlign: "left", transition: "all .15s ease",
+                    borderBottom: "1px solid #f1f5f9",
+                  }}>
+                  <span>{tab.icon}</span> {tab.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Main content ─────────────────────────────────────────────────── */}
+          <div>
+
+            {/* TAB: Agent Profile */}
+            {activeTab === "profile" && (
+              <div className="card">
+                <div className="card__header">
+                  <h2 className="card__title">Profili i Agjentit</h2>
+                  <span style={{ fontSize: 12.5, color: "#94a3b8" }}>
+                    {profile ? "Ndrysho" : "Krijo"} profilin tënd profesional
+                  </span>
+                </div>
+                <div className="card__body">
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+                    <Field label="Telefon">
+                      <input className="form-input" value={profileForm.phone}
+                        onChange={e => setP("phone", e.target.value)}
+                        placeholder="+38344123456" />
+                    </Field>
+                    <Field label="Licença">
+                      <input className="form-input" value={profileForm.license}
+                        onChange={e => setP("license", e.target.value)}
+                        placeholder="REA-2024-001" />
+                    </Field>
+                  </div>
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+                    <Field label="Specializimi">
+                      <input className="form-input" value={profileForm.specialization}
+                        onChange={e => setP("specialization", e.target.value)}
+                        placeholder="Prona rezidenciale, Komerciale..." />
+                    </Field>
+                    <Field label="Vite Përvojë">
+                      <input className="form-input" type="number" min="0" max="60"
+                        value={profileForm.experience_years}
+                        onChange={e => setP("experience_years", e.target.value)}
+                        placeholder="0" />
+                    </Field>
+                  </div>
+                  <Field label="Bio">
+                    <textarea className="form-textarea" rows={4}
+                      value={profileForm.bio}
+                      onChange={e => setP("bio", e.target.value)}
+                      placeholder="Rrëfim i shkurtër profesional..."
+                      style={{
+                        width: "100%", padding: "9px 12px",
+                        border: "1px solid #cbd5e1", borderRadius: 10,
+                        fontSize: 14, fontFamily: "inherit", resize: "vertical",
+                        outline: "none",
+                      }} />
+                  </Field>
+                  <Field label="URL e Fotos">
+                    <input className="form-input" value={profileForm.photo_url}
+                      onChange={e => setP("photo_url", e.target.value)}
+                      placeholder="https://..." />
+                  </Field>
+                  <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 8 }}>
+                    <button className="btn btn--primary" onClick={handleSaveProfile} disabled={saving}>
+                      {saving ? "Duke ruajtur..." : profile ? "Ruaj ndryshimet" : "Krijo profilin"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* TAB: Account */}
+            {activeTab === "account" && (
+              <div className="card">
+                <div className="card__header">
+                  <h2 className="card__title">Të dhënat e llogarisë</h2>
+                </div>
+                <div className="card__body">
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+                    <Field label="Emri">
+                      <input className="form-input" value={userForm.first_name}
+                        onChange={e => setU("first_name", e.target.value)} />
+                    </Field>
+                    <Field label="Mbiemri">
+                      <input className="form-input" value={userForm.last_name}
+                        onChange={e => setU("last_name", e.target.value)} />
+                    </Field>
+                  </div>
+                  <Field label="Email">
+                    <input className="form-input" type="email" value={userForm.email}
+                      onChange={e => setU("email", e.target.value)} />
+                  </Field>
+                  <div style={{
+                    background: "#f8fafc", border: "1px solid #e8edf4",
+                    borderRadius: 8, padding: "10px 14px", fontSize: 13, color: "#64748b",
+                  }}>
+                    Roli: <strong style={{ color: "#6366f1" }}>Agent</strong> &nbsp;·&nbsp;
+                    Tenant ID: <strong>{userInfo?.tenant_id}</strong> &nbsp;·&nbsp;
+                    Status: <strong style={{ color: userInfo?.is_active ? "#059669" : "#dc2626" }}>
+                      {userInfo?.is_active ? "Aktiv" : "Joaktiv"}
+                    </strong>
+                  </div>
+                  <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 14 }}>
+                    <button className="btn btn--primary" onClick={handleSaveUser} disabled={savingUser}>
+                      {savingUser ? "Duke ruajtur..." : "Ruaj ndryshimet"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* TAB: Password */}
+            {activeTab === "password" && (
+              <div className="card">
+                <div className="card__header">
+                  <h2 className="card__title">Ndrysho fjalëkalimin</h2>
+                </div>
+                <div className="card__body">
+                  <Field label="Fjalëkalimi aktual" required>
+                    <input className="form-input" type="password"
+                      value={pwForm.current_password}
+                      onChange={e => setPw("current_password", e.target.value)}
+                      placeholder="••••••••" />
+                  </Field>
+                  <Field label="Fjalëkalimi i ri" required>
+                    <input className="form-input" type="password"
+                      value={pwForm.new_password}
+                      onChange={e => setPw("new_password", e.target.value)}
+                      placeholder="Min. 8 karaktere, shkronja + numër" />
+                  </Field>
+                  <Field label="Konfirmo fjalëkalimin" required>
+                    <input className="form-input" type="password"
+                      value={pwForm.confirm}
+                      onChange={e => setPw("confirm", e.target.value)}
+                      placeholder="••••••••" />
+                  </Field>
+                  {pwForm.new_password && pwForm.confirm && pwForm.new_password !== pwForm.confirm && (
+                    <p style={{ fontSize: 12.5, color: "#dc2626", marginTop: -10, marginBottom: 14 }}>
+                      Fjalëkalimet nuk përputhen
+                    </p>
+                  )}
+                  <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                    <button className="btn btn--primary" onClick={handleChangePw}
+                      disabled={savingPw || !pwForm.current_password || !pwForm.new_password}>
+                      {savingPw ? "Duke ndryshuar..." : "Ndrysho fjalëkalimin"}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {toast && (
+        <Toast key={toast.key} msg={toast.msg} type={toast.type}
+          onDone={() => setToast(null)} />
+      )}
+    </MainLayout>
+  );
+}

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -11,7 +11,8 @@ import AgentProperties from "../pages/agent/Properties";
 import AgentPropeties from "../pages/agent/Properties";
 
 import AgentSales from "../pages/agent/AgentSales";
-
+import AgentProfile from "../pages/agent/AgentProfile";
+import AgentLeads from "../pages/agent/AgentLeads";
 
 export default function AppRoutes() {
     return (
@@ -33,6 +34,9 @@ export default function AppRoutes() {
     {/* PUBLIC / AGENT */}
      <Route path="/agent/properties" element={<AgentPropeties />} />
     <Route path="/agent/sales" element={<AgentSales />} />
+
+    <Route path="/agent/profile"     element={<AgentProfile />} />
+<Route path="/agent/leads"       element={<AgentLeads />} />
 </Routes>
     );
 }


### PR DESCRIPTION
## Konteksti
Implementim i UI-t për rolin AGENT për menaxhimin e Leads dhe Profile-it,
sipas kërkesave të Issue #64, me shtimin e flow-it Accept/Decline.

## Çfarë u implementua

### AgentProfile.jsx — faqe e re
- `GET /api/users/agents/me` — ngarkon profilin e agjentit
- `PUT /api/users/agents/me` — ruan ndryshimet e profilit
- Tre tab: Profili i Agjentit, Llogaria, Fjalëkalimi
- Avatar dinamik (foto ose iniciale)
- Vlerësimi me yje nga databaza

### AgentLeads.jsx — faqe e re
- Tre tab: My Leads, All Leads, By Property
- Tabelë me status badge për çdo lead
- `GET /api/leads/my/agent` — leads të agjentit
- `GET /api/leads?status=` — të gjitha leads me filtrim
- `GET /api/leads/property/{id}` — leads sipas pronës
- `PATCH /api/leads/{id}/status` — ndryshim statusi

### Butonat e veprimeve
- **Accept** — `NEW → IN_PROGRESS`
- **Complete** — `IN_PROGRESS → DONE`
- **Reject** — `IN_PROGRESS → REJECTED`

## Ndryshimet shtesë mbi Issue #64

### Decline flow (i lidhur me ndryshimet backend)
- Shtuar butoni **Decline** për leads NEW në My Leads
- `PATCH /api/leads/{id}/decline` — lead kthehet tek admini
- Pas Decline, lead largohet automatikisht nga lista My Leads

### UX përmirësime
- Butonat shfaqen vetëm në My Leads — jo në All Leads/By Property
- Mesazhe kontekstuale në All Leads:
  - `🕐 Pa asignuar` — lead pa agjent
  - `⏳ Pret pranimin` — lead me agjent, status NEW
- Modal me banner: "Ky lead ju është asignuar juve" kur
  `assigned_agent_id` përputhet me ID-në e userit aktual
- Kolona Agjenti shfaqet vetëm jashtë My Leads
- `DECLINED` hequr nga dropdown filtrimit (status tranzitor)
- Closes #64 