### PR TITLE
feat: replace manual ID inputs with user-friendly dropdowns

### DIFF
--- a/src/pages/agent/Contracts.jsx
+++ b/src/pages/agent/Contracts.jsx
@@ -142,62 +142,151 @@ function ContractModal({ initial, onClose, onSuccess, notify }) {
     currency:          initial?.currency          ?? "EUR",
     contract_file_url: initial?.contract_file_url ?? "",
   });
+  
+  const [properties, setProperties] = useState([]);
+  const [listings, setListings] = useState([]);
+  const [loadingProps, setLoadingProps] = useState(false);
+  const [loadingListings, setLoadingListings] = useState(false);
   const [saving, setSaving] = useState(false);
   const set = (k, v) => setForm(p => ({ ...p, [k]: v }));
 
-  const handleSubmit = async () => {
-    if (!form.property_id || !form.client_id || !form.start_date || !form.end_date || !form.rent) {
-      notify("Plotëso fushat e detyrueshme", "error");
-      return;
-    }
-    if (form.end_date <= form.start_date) {
-      notify("Data e përfundimit duhet të jetë pas datës fillimit", "error");
-      return;
-    }
-    setSaving(true);
-    try {
-      const payload = {
-        property_id:       Number(form.property_id),
-        listing_id:        form.listing_id ? Number(form.listing_id) : null,
-        client_id:         Number(form.client_id),
-        start_date:        form.start_date,
-        end_date:          form.end_date,
-        rent:              Number(form.rent),
-        deposit:           form.deposit ? Number(form.deposit) : null,
-        currency:          form.currency,
-        contract_file_url: form.contract_file_url || null,
-      };
-      if (initial) {
-        await api.put(`/api/contracts/lease/${initial.id}`, payload);
-      } else {
-        await api.post("/api/contracts/lease", payload);
+  // Fetch all properties on mount
+  useEffect(() => {
+    const fetchProperties = async () => {
+      setLoadingProps(true);
+      try {
+        const res = await api.get("/api/properties?size=100");
+        setProperties(res.data.content || []);
+      } catch (err) {
+        console.error("Gabim gjatë ngarkimit të properties", err);
+      } finally {
+        setLoadingProps(false);
       }
-      onSuccess();
-    } catch (err) {
-      notify(err.response?.data?.message || "Gabim gjatë ruajtjes", "error");
-    } finally {
-      setSaving(false);
+    };
+    fetchProperties();
+  }, []);
+
+  // Fetch listings when property is selected
+  useEffect(() => {
+    const fetchListingsForProperty = async () => {
+      if (!form.property_id) {
+        setListings([]);
+        return;
+      }
+      setLoadingListings(true);
+      try {
+        const res = await api.get(`/api/rentals/listings/property/${form.property_id}`);
+        setListings(res.data || []);
+      } catch (err) {
+        console.error("Gabim gjatë ngarkimit të listings për property", err);
+        setListings([]);
+      } finally {
+        setLoadingListings(false);
+      }
+    };
+    fetchListingsForProperty();
+  }, [form.property_id]);
+
+  const handleSubmit = async () => {
+  console.log("=== DEBUG FORM VALUES ===");
+  console.log("property_id:", form.property_id, "type:", typeof form.property_id);
+  console.log("client_id:", form.client_id, "type:", typeof form.client_id);
+  console.log("start_date:", form.start_date, "type:", typeof form.start_date);
+  console.log("end_date:", form.end_date, "type:", typeof form.end_date);
+  console.log("rent:", form.rent, "type:", typeof form.rent);
+  console.log("listing_id:", form.listing_id);
+  console.log("deposit:", form.deposit);
+  console.log("currency:", form.currency);
+  
+  if (!form.property_id || !form.client_id || !form.start_date || !form.end_date || !form.rent) {
+    console.log("VALIDATION FAILED - missing field");
+    notify("Plotëso fushat e detyrueshme", "error");
+    return;
+  }
+  if (form.end_date <= form.start_date) {
+    console.log("VALIDATION FAILED - end date <= start date");
+    notify("Data e përfundimit duhet të jetë pas datës fillimit", "error");
+    return;
+  }
+  
+  console.log("VALIDATION PASSED - sending request");
+  setSaving(true);
+  try {
+    const payload = {
+      property_id:       Number(form.property_id),
+      listing_id:        form.listing_id ? Number(form.listing_id) : null,
+      client_id:         Number(form.client_id),
+      start_date:        form.start_date,
+      end_date:          form.end_date,
+      rent:              Number(form.rent),
+      deposit:           form.deposit ? Number(form.deposit) : null,
+      currency:          form.currency,
+      contract_file_url: form.contract_file_url || null,
+    };
+    console.log("PAYLOAD:", payload);
+    if (initial) {
+      await api.put(`/api/contracts/lease/${initial.id}`, payload);
+    } else {
+      await api.post("/api/contracts/lease", payload);
     }
-  };
+    onSuccess();
+  } catch (err) {
+    console.error("ERROR:", err.response?.data);
+    notify(err.response?.data?.message || "Gabim gjatë ruajtjes", "error");
+  } finally {
+    setSaving(false);
+  }
+};
+
+  const activeListings = listings.filter(l => l.status === "ACTIVE");
 
   return (
     <Modal title={initial ? `Edit Kontratë #${initial.id}` : "New Lease Contract"}
       onClose={onClose} wide>
       <Row2>
-        <Field label="Property ID" required>
-          <input className="form-input" type="number" value={form.property_id}
-            onChange={e => set("property_id", e.target.value)}
-            disabled={!!initial} placeholder="42" />
+        <Field label="Property" required>
+          <select 
+            className="form-select" 
+            value={form.property_id}
+            onChange={e => {
+              set("property_id", e.target.value);
+              set("listing_id", "");
+            }}
+            disabled={!!initial || loadingProps}
+          >
+            <option value="">Zgjidh një property...</option>
+            {properties.map(prop => (
+              <option key={prop.id} value={prop.id}>
+                {prop.title || prop.address || `Property #${prop.id}`}
+              </option>
+            ))}
+          </select>
         </Field>
-        <Field label="Listing ID">
-          <input className="form-input" type="number" value={form.listing_id}
-            onChange={e => set("listing_id", e.target.value)} placeholder="(opcional)" />
+        <Field label="Listing (opcional)">
+          <select 
+            className="form-select" 
+            value={form.listing_id}
+            onChange={e => set("listing_id", e.target.value)}
+            disabled={!form.property_id || loadingListings}
+          >
+            <option value="">-- Pa listing --</option>
+            {activeListings.map(listing => (
+              <option key={listing.id} value={listing.id}>
+                {listing.title || `Listing #${listing.id}`} - {listing.price}€/{listing.price_period?.toLowerCase()}
+              </option>
+            ))}
+          </select>
+          {form.property_id && activeListings.length === 0 && !loadingListings && (
+            <p style={{ fontSize: 11, color: "#94a3b8", marginTop: 4 }}>
+              Nuk ka listings aktive për këtë property
+            </p>
+          )}
         </Field>
       </Row2>
       <Field label="Client ID" required>
         <input className="form-input" type="number" value={form.client_id}
           onChange={e => set("client_id", e.target.value)}
-          disabled={!!initial} placeholder="ID e klientit" />
+          placeholder="ID e klientit" />
       </Field>
       <Row2>
         <Field label="Data fillimit" required>
@@ -305,6 +394,7 @@ function ContractDetailModal({ contract, onClose, onEdit, onStatusChange }) {
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 18 }}>
         {[
           { label: "Property ID",   value: `#${contract.property_id}` },
+          { label: "Listing ID",    value: contract.listing_id ? `#${contract.listing_id}` : "—" },
           { label: "Client ID",     value: `#${contract.client_id}` },
           { label: "Agjent ID",     value: contract.agent_id ? `#${contract.agent_id}` : "—" },
           { label: "Statusi",       value: <StatusBadge status={contract.status} /> },
@@ -354,7 +444,7 @@ function ContractDetailModal({ contract, onClose, onEdit, onStatusChange }) {
 // ═══════════════════════════════════════════════════════════════════════════════
 export default function AgentContracts() {
   const { user } = useContext(AuthContext);
-  const [tab, setTab] = useState("my");   // "my" | "all" | "expiring"
+  const [tab, setTab] = useState("my");
   const [contracts, setContracts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(0);
@@ -426,7 +516,6 @@ export default function AgentContracts() {
         </button>
       </div>
 
-      {/* Tabs */}
       <div style={{ display: "flex", gap: 4, borderBottom: "1px solid #e8edf4",
         marginBottom: 20, paddingBottom: 0 }}>
         {tabs.map(t => (
@@ -443,7 +532,6 @@ export default function AgentContracts() {
         ))}
       </div>
 
-      {/* Table */}
       <div className="card">
         <div className="card__header">
           <h2 className="card__title">

--- a/src/pages/agent/Payments.jsx
+++ b/src/pages/agent/Payments.jsx
@@ -132,6 +132,8 @@ function Modal({ title, onClose, children, wide = false }) {
 
 // ─── Create Payment Modal ─────────────────────────────────────────────────────
 function CreatePaymentModal({ contractId, onClose, onSuccess, notify }) {
+  const [contracts, setContracts] = useState([]);
+  const [loadingContracts, setLoadingContracts] = useState(false);
   const [form, setForm] = useState({
     contract_id:    contractId || "",
     amount:         "",
@@ -144,9 +146,25 @@ function CreatePaymentModal({ contractId, onClose, onSuccess, notify }) {
   const [saving, setSaving] = useState(false);
   const set = (k, v) => setForm(p => ({ ...p, [k]: v }));
 
+  // Fetch contracts for dropdown
+  useEffect(() => {
+    const fetchContracts = async () => {
+      setLoadingContracts(true);
+      try {
+        const res = await api.get("/api/contracts/lease?page=0&size=100");
+        setContracts(res.data.content || []);
+      } catch (err) {
+        console.error("Gabim gjatë ngarkimit të kontratave", err);
+      } finally {
+        setLoadingContracts(false);
+      }
+    };
+    fetchContracts();
+  }, []);
+
   const handleSubmit = async () => {
     if (!form.contract_id || !form.amount || !form.due_date) {
-      notify("Contract ID, shuma dhe due date janë të detyrueshme", "error");
+      notify("Kontrata, shuma dhe due date janë të detyrueshme", "error");
       return;
     }
     setSaving(true);
@@ -168,12 +186,27 @@ function CreatePaymentModal({ contractId, onClose, onSuccess, notify }) {
     }
   };
 
+  // Get contract display text
+  const getContractDisplay = (contract) => {
+    return `#${contract.id} - Client #${contract.client_id} - ${fmtMoney(contract.rent)}`;
+  };
+
   return (
     <Modal title="New Lease Payment" onClose={onClose}>
-      <Field label="Contract ID" required>
-        <input className="form-input" type="number" value={form.contract_id}
+      <Field label="Kontrata" required>
+        <select 
+          className="form-select" 
+          value={form.contract_id}
           onChange={e => set("contract_id", e.target.value)}
-          placeholder="ID e kontratës" />
+          disabled={loadingContracts}
+        >
+          <option value="">Zgjidh një kontratë...</option>
+          {contracts.map(contract => (
+            <option key={contract.id} value={contract.id}>
+              {getContractDisplay(contract)}
+            </option>
+          ))}
+        </select>
       </Field>
       <Row2>
         <Field label="Shuma" required>
@@ -284,11 +317,13 @@ function MarkPaidModal({ payment, onClose, onSuccess, notify }) {
 // ═══════════════════════════════════════════════════════════════════════════════
 export default function AgentPayments() {
   const [tab, setTab] = useState("contract");  // "contract" | "status" | "overdue"
-  const [contractId, setContractId] = useState("");
+  const [selectedContractId, setSelectedContractId] = useState("");
+  const [contracts, setContracts] = useState([]);
   const [statusFilter, setStatusFilter] = useState("PENDING");
   const [payments, setPayments] = useState([]);
   const [summary, setSummary] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [loadingContracts, setLoadingContracts] = useState(false);
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [createOpen, setCreateOpen] = useState(false);
@@ -299,19 +334,38 @@ export default function AgentPayments() {
   const notify = useCallback((msg, type = "success") =>
     setToast({ msg, type, key: Date.now() }), []);
 
-  // ── Fetch revenue once ────────────────────────────────────────────────────────
+  // Fetch all contracts for dropdown
+  useEffect(() => {
+    const fetchContracts = async () => {
+      setLoadingContracts(true);
+      try {
+        const res = await api.get("/api/contracts/lease?page=0&size=100");
+        setContracts(res.data.content || []);
+      } catch (err) {
+        console.error("Gabim gjatë ngarkimit të kontratave", err);
+      } finally {
+        setLoadingContracts(false);
+      }
+    };
+    fetchContracts();
+  }, []);
+
+  // Fetch revenue once
   useEffect(() => {
     api.get("/api/payments/revenue").then(r => setRevenue(r.data)).catch(() => {});
   }, []);
 
-  // ── Fetch by contract ─────────────────────────────────────────────────────────
-  const fetchByContract = async () => {
-    if (!contractId) { notify("Shkruaj Contract ID", "error"); return; }
+  // Fetch by contract
+  const fetchByContract = useCallback(async () => {
+    if (!selectedContractId) { 
+      notify("Zgjidh një kontratë", "error"); 
+      return; 
+    }
     setLoading(true);
     try {
       const [listRes, sumRes] = await Promise.all([
-        api.get(`/api/payments/contract/${contractId}`),
-        api.get(`/api/payments/contract/${contractId}/summary`),
+        api.get(`/api/payments/contract/${selectedContractId}`),
+        api.get(`/api/payments/contract/${selectedContractId}/summary`),
       ]);
       setPayments(Array.isArray(listRes.data) ? listRes.data : []);
       setSummary(sumRes.data);
@@ -321,9 +375,9 @@ export default function AgentPayments() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [selectedContractId, notify]);
 
-  // ── Fetch by status ───────────────────────────────────────────────────────────
+  // Fetch by status
   const fetchByStatus = useCallback(async () => {
     if (tab !== "status") return;
     setLoading(true);
@@ -339,7 +393,7 @@ export default function AgentPayments() {
     }
   }, [tab, statusFilter, page, notify]);
 
-  // ── Fetch overdue ─────────────────────────────────────────────────────────────
+  // Fetch overdue
   const fetchOverdue = useCallback(async () => {
     if (tab !== "overdue") return;
     setLoading(true);
@@ -358,14 +412,33 @@ export default function AgentPayments() {
   useEffect(() => {
     if (tab === "status") fetchByStatus();
     if (tab === "overdue") fetchOverdue();
-    if (tab === "contract") { setPayments([]); setSummary(null); }
-  }, [tab, fetchByStatus, fetchOverdue]);
+    if (tab === "contract") { 
+      if (selectedContractId) {
+        fetchByContract();
+      } else {
+        setPayments([]); 
+        setSummary(null);
+      }
+    }
+  }, [tab, fetchByStatus, fetchOverdue, fetchByContract, selectedContractId]);
 
-  // ── Mark as paid success ──────────────────────────────────────────────────────
+  // Handle contract selection change
+  const handleContractChange = (e) => {
+    const value = e.target.value;
+    setSelectedContractId(value);
+    if (value) {
+      // Will trigger fetch via useEffect when selectedContractId changes and tab is "contract"
+    } else {
+      setPayments([]);
+      setSummary(null);
+    }
+  };
+
+  // Mark as paid success
   const handleMarkPaidSuccess = () => {
     setMarkPaidTarget(null);
     notify("Pagesa u shënua si PAID");
-    if (tab === "contract") fetchByContract();
+    if (tab === "contract" && selectedContractId) fetchByContract();
     else if (tab === "status") fetchByStatus();
     else fetchOverdue();
   };
@@ -377,6 +450,11 @@ export default function AgentPayments() {
   ];
 
   const overdueCount = payments.filter(p => isOverdue(p)).length;
+
+  // Get contract display text for dropdown
+  const getContractDisplay = (contract) => {
+    return `#${contract.id} - Client #${contract.client_id} - ${fmtMoney(contract.rent)}`;
+  };
 
   return (
     <MainLayout role="agent">
@@ -468,13 +546,20 @@ export default function AgentPayments() {
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           {tab === "contract" && (
             <>
-              <input className="form-input" type="number"
-                style={{ height: 34, padding: "0 10px", fontSize: 13, width: 140 }}
-                placeholder="Contract ID..."
-                value={contractId}
-                onChange={e => setContractId(e.target.value)}
-                onKeyDown={e => e.key === "Enter" && fetchByContract()} />
-              <button className="btn btn--secondary btn--sm" onClick={fetchByContract}>Load</button>
+              <select 
+                className="form-select"
+                style={{ height: 34, padding: "0 10px", fontSize: 13, width: 260 }}
+                value={selectedContractId}
+                onChange={handleContractChange}
+                disabled={loadingContracts}
+              >
+                <option value="">-- Zgjidh një kontratë --</option>
+                {contracts.map(contract => (
+                  <option key={contract.id} value={contract.id}>
+                    {getContractDisplay(contract)}
+                  </option>
+                ))}
+              </select>
             </>
           )}
           {tab === "status" && (
@@ -541,8 +626,8 @@ export default function AgentPayments() {
       <div className="card">
         <div className="card__header">
           <h2 className="card__title">
-            {tab === "contract" && contractId ? `Pagesat — Kontratë #${contractId}` : ""}
-            {tab === "contract" && !contractId ? "Pagesat" : ""}
+            {tab === "contract" && selectedContractId ? `Pagesat — Kontratë #${selectedContractId}` : ""}
+            {tab === "contract" && !selectedContractId ? "Pagesat" : ""}
             {tab === "status"   ? `Pagesat — ${statusFilter}` : ""}
             {tab === "overdue"  ? "Pagesat me Vonesë" : ""}
           </h2>
@@ -558,8 +643,8 @@ export default function AgentPayments() {
           <EmptyState
             icon={tab === "contract" ? "💳" : tab === "overdue" ? "✅" : "💳"}
             text={
-              tab === "contract" && !contractId ? "Shkruaj Contract ID dhe kliko Load" :
-              tab === "contract" && contractId  ? "Nuk ka pagesa për këtë kontratë" :
+              tab === "contract" && !selectedContractId ? "Zgjidh një kontratë nga lista" :
+              tab === "contract" && selectedContractId  ? "Nuk ka pagesa për këtë kontratë" :
               tab === "overdue"                 ? "Nuk ka pagesa me vonesë 🎉" :
               `Nuk ka pagesa me status ${statusFilter}`
             }
@@ -635,12 +720,14 @@ export default function AgentPayments() {
 
       {createOpen && (
         <CreatePaymentModal
-          contractId={contractId || ""}
+          contractId={selectedContractId || ""}
           onClose={() => setCreateOpen(false)}
           onSuccess={() => {
             setCreateOpen(false);
             notify("Pagesa u krijua");
-            if (contractId) fetchByContract();
+            if (tab === "contract" && selectedContractId) fetchByContract();
+            else if (tab === "status") fetchByStatus();
+            else fetchOverdue();
           }}
           notify={notify}
         />

--- a/src/pages/agent/RentalApplications.jsx
+++ b/src/pages/agent/RentalApplications.jsx
@@ -220,9 +220,11 @@ function AppDetailModal({ app, onClose, onReview }) {
 // MAIN PAGE
 // ═══════════════════════════════════════════════════════════════════════════════
 export default function AgentRentalApplications() {
-  const [listingId, setListingId] = useState("");
+  const [selectedListingId, setSelectedListingId] = useState("");
+  const [listings, setListings] = useState([]);
   const [applications, setApplications] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [loadingListings, setLoadingListings] = useState(true);
   const [selectedApp, setSelectedApp] = useState(null);
   const [toast, setToast] = useState(null);
 
@@ -237,16 +239,46 @@ export default function AgentRentalApplications() {
   const notify = useCallback((msg, type = "success") =>
     setToast({ msg, type, key: Date.now() }), []);
 
-  const fetchApplications = async () => {
-    if (!listingId) { notify("Shkruaj Listing ID", "error"); return; }
+  // Fetch all rental listings on mount
+  useEffect(() => {
+    const fetchListings = async () => {
+      setLoadingListings(true);
+      try {
+        const res = await api.get("/api/rentals/listings?page=0&size=100&sortBy=createdAt&sortDir=desc");
+        setListings(res.data.content || []);
+      } catch (err) {
+        console.error("Gabim gjatë ngarkimit të listings", err);
+      } finally {
+        setLoadingListings(false);
+      }
+    };
+    fetchListings();
+  }, []);
+
+  const fetchApplications = async (listingId) => {
+    if (!listingId) return;
     setLoading(true);
     try {
       const res = await api.get(`/api/rentals/applications/listing/${listingId}`);
       setApplications(Array.isArray(res.data) ? res.data : []);
+      if (res.data.length === 0) {
+        notify("Nuk ka aplikime për këtë listing", "info");
+      }
     } catch {
-      notify("Gabim — listing nuk u gjet ose nuk ka aplikime", "error");
+      notify("Gabim — nuk mund të ngarkohen aplikimet", "error");
+      setApplications([]);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleListingChange = (e) => {
+    const value = e.target.value;
+    setSelectedListingId(value);
+    if (value) {
+      fetchApplications(value);
+    } else {
+      setApplications([]);
     }
   };
 
@@ -266,6 +298,11 @@ export default function AgentRentalApplications() {
     } catch (err) {
       notify(err.response?.data?.message || "Gabim", "error");
     }
+  };
+
+  const getListingDisplayText = (listing) => {
+    const title = listing.title || `Property #${listing.property_id}`;
+    return `${title}`;
   };
 
   const statCards = [
@@ -289,30 +326,29 @@ export default function AgentRentalApplications() {
         </div>
       </div>
 
-      {/* Search bar */}
+      {/* Dropdown selector */}
       <div className="card" style={{ marginBottom: 20 }}>
-        <div style={{ padding: "18px 20px", display: "flex", gap: 12, alignItems: "center" }}>
-          <div>
-            <p style={{ fontSize: 13, fontWeight: 500, marginBottom: 6 }}>Listing ID</p>
-            <div style={{ display: "flex", gap: 8 }}>
-              <input className="form-input" type="number"
-                style={{ width: 160, height: 36 }}
-                placeholder="ID e listing..."
-                value={listingId}
-                onChange={e => setListingId(e.target.value)}
-                onKeyDown={e => e.key === "Enter" && fetchApplications()} />
-              <button className="btn btn--primary" onClick={fetchApplications}>
-                Shiko aplikimet
-              </button>
-            </div>
-          </div>
-          <p style={{ fontSize: 12.5, color: "#94a3b8", marginTop: 20 }}>
-            Shkruaj ID-në e listingut dhe kliko butonin për të parë aplikimet
-          </p>
+        <div style={{ padding: "18px 20px" }}>
+          <p style={{ fontSize: 13, fontWeight: 500, marginBottom: 6 }}>Zgjidh Rental Listing</p>
+          <select
+            className="form-select"
+            value={selectedListingId}
+            onChange={handleListingChange}
+            disabled={loadingListings}
+            style={{ width: "100%", maxWidth: 400 }}
+          >
+            <option value="">-- Zgjidh një listing --</option>
+            {listings.map(listing => (
+              <option key={listing.id} value={listing.id}>
+                {getListingDisplayText(listing)}
+              </option>
+            ))}
+          </select>
+          {loadingListings && <div style={{ marginTop: 8 }}><Loader /></div>}
         </div>
       </div>
 
-      {/* Stats — show only after loading */}
+      {/* Stats — show only when there are applications */}
       {applications.length > 0 && (
         <div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)",
           gap: 14, marginBottom: 20 }}>
@@ -329,15 +365,17 @@ export default function AgentRentalApplications() {
       <div className="card">
         <div className="card__header">
           <h2 className="card__title">
-            {listingId
-              ? `Aplikimet për Listing #${listingId}`
+            {selectedListingId && listings.find(l => l.id == selectedListingId)
+              ? `Aplikimet për: ${listings.find(l => l.id == selectedListingId)?.title || `Listing #${selectedListingId}`}`
               : "Aplikimet"}
           </h2>
         </div>
 
         {loading ? <Loader /> : applications.length === 0 ? (
-          <EmptyState icon="📝"
-            text={listingId ? "Nuk ka aplikime për këtë listing" : "Shkruaj Listing ID për të shikuar aplikimet"} />
+          <EmptyState 
+            icon="📝"
+            text={selectedListingId ? "Nuk ka aplikime për këtë listing" : "Zgjidh një listing nga lista për të parë aplikimet"} 
+          />
         ) : (
           <div className="table-wrap">
             <table className="table">

--- a/src/pages/agent/Rentals.jsx
+++ b/src/pages/agent/Rentals.jsx
@@ -138,12 +138,33 @@ function ListingModal({ initial, onClose, onSuccess, notify }) {
     min_lease_months: initial?.min_lease_months ?? 12,
     status:           initial?.status           ?? "ACTIVE",
   });
+  
+  const [properties, setProperties] = useState([]);
+  const [loadingProps, setLoadingProps] = useState(false);
   const [saving, setSaving] = useState(false);
   const set = (k, v) => setForm(p => ({ ...p, [k]: v }));
 
+  // Fetch active properties for dropdown
+  useEffect(() => {
+    if (!initial) {
+      const fetchProperties = async () => {
+        setLoadingProps(true);
+        try {
+          const res = await api.get("/api/properties?status=ACTIVE&size=100");
+          setProperties(res.data.content || []);
+        } catch (err) {
+          console.error("Gabim gjatë ngarkimit të properties", err);
+        } finally {
+          setLoadingProps(false);
+        }
+      };
+      fetchProperties();
+    }
+  }, [initial]);
+
   const handleSubmit = async () => {
     if (!form.property_id || !form.price) {
-      notify("Property ID dhe çmimi janë të detyrueshme", "error");
+      notify("Property dhe çmimi janë të detyrueshme", "error");
       return;
     }
     setSaving(true);
@@ -178,10 +199,24 @@ function ListingModal({ initial, onClose, onSuccess, notify }) {
     <Modal title={initial ? `Edit Listing #${initial.id}` : "New Rental Listing"}
       onClose={onClose} wide>
       <Row2>
-        <Field label="Property ID" required>
-          <input className="form-input" type="number" value={form.property_id}
-            onChange={e => set("property_id", e.target.value)}
-            disabled={!!initial} placeholder="42" />
+        <Field label="Property" required>
+          {initial ? (
+            <input className="form-input" type="number" value={form.property_id} disabled />
+          ) : (
+            <select 
+              className="form-select" 
+              value={form.property_id}
+              onChange={e => set("property_id", e.target.value)}
+              disabled={loadingProps}
+            >
+              <option value="">Zgjidh një property...</option>
+              {properties.map(prop => (
+                <option key={prop.id} value={prop.id}>
+                  #{prop.id} - {prop.title || prop.address || "Pa titull"}
+                </option>
+              ))}
+            </select>
+          )}
         </Field>
         <Field label="Titull">
           <input className="form-input" value={form.title}


### PR DESCRIPTION
- AgentRentals: Property dropdown for new listings instead of manual property_id
- AgentRentalApplications: Property + Listing dropdowns for filtering applications
- AgentContracts: Property and Listing dropdowns, remove client dropdown requirement
- AgentPayments: Contract dropdown instead of manual contract_id
- Fix validation issues and improve UX across all rental modules
- closes #79 