### PR TITLE
[CACHE] Setup React Query + Live Admin Dashboard Stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "real-estate-management-system-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.100.9",
         "axios": "^1.15.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -56,7 +57,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -266,6 +266,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -273,6 +298,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -863,6 +889,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -894,7 +946,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -941,7 +992,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1067,7 +1117,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1363,7 +1412,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2474,7 +2522,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2545,7 +2592,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2555,7 +2601,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2818,7 +2863,6 @@
       "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2943,7 +2987,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.100.9",
     "axios": "^1.15.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/hooks/usePropertyCache.js
+++ b/src/hooks/usePropertyCache.js
@@ -1,0 +1,36 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import api from "../api/axios";
+
+// Properties — cache 5 min (sinkronizohet me Redis backend)
+export function useProperties(page = 0, size = 12) {
+  return useQuery({
+    queryKey: ["properties", page, size],
+    queryFn:  () => api.get(`/api/properties?page=${page}&size=${size}`).then(r => r.data),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+// Dashboard stats — cache 10 min (sinkronizohet me Redis backend)
+export function useDashboardStats() {
+  return useQuery({
+    queryKey: ["dashboard-stats"],
+    queryFn:  () => api.get("/api/admin/dashboard/stats").then(r => r.data),
+    staleTime: 10 * 60 * 1000,
+  });
+}
+
+// Notification unread count — cache 60 sekonda
+export function useUnreadCount() {
+  return useQuery({
+    queryKey: ["unread-count"],
+    queryFn:  () => api.get("/api/notifications/unread/count").then(r => r.data.unread_count),
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000, // auto-refetch çdo 60 sek
+  });
+}
+
+// Invalidate cache kur krijon/ndrysho pronë
+export function useInvalidateProperties() {
+  const qc = useQueryClient();
+  return () => qc.invalidateQueries({ queryKey: ["properties"] });
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,17 +1,28 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import AuthProvider from "./context/AuthProvider";
 
-import App from "./App.jsx";
-import AuthProvider from "./context/AuthProvider.jsx";
-import "./index.css";
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      gcTime:    10 * 60 * 1000,
+      retry: 1,
+    },
+  },
+});
 
-ReactDOM.createRoot(document.getElementById("root")).render(
-    <React.StrictMode>
-        <BrowserRouter>
-            <AuthProvider>
-                <App />
-            </AuthProvider>
-        </BrowserRouter>
-    </React.StrictMode>
+createRoot(document.getElementById("root")).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  </StrictMode>
 );

--- a/src/pages/admin/AdminDashboard.jsx
+++ b/src/pages/admin/AdminDashboard.jsx
@@ -1,95 +1,6 @@
 import MainLayout from "../../components/layout/Layout";
- 
-const stats = [
-  {
-    label: "Total Properties",
-    value: "248",
-    delta: "+12%",
-    up: true,
-    color: "#eef2ff",
-    iconColor: "#6366f1",
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#6366f1" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>
-      </svg>
-    ),
-  },
-  {
-    label: "Active Rentals",
-    value: "143",
-    delta: "+8%",
-    up: true,
-    color: "#f0f9ff",
-    iconColor: "#0ea5e9",
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#0ea5e9" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2 10.58 12.42M13 7l3 3M18 2l3 3-6 6-3-3"/>
-      </svg>
-    ),
-  },
-  {
-    label: "Sales This Month",
-    value: "34",
-    delta: "-3%",
-    up: false,
-    color: "#fff7ed",
-    iconColor: "#f97316",
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#f97316" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
-      </svg>
-    ),
-  },
-  {
-    label: "Revenue",
-    value: "€84.2k",
-    delta: "+21%",
-    up: true,
-    color: "#ecfdf5",
-    iconColor: "#10b981",
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#10b981" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>
-      </svg>
-    ),
-  },
-  {
-    label: "Active Agents",
-    value: "18",
-    delta: "+2",
-    up: true,
-    color: "#fdf4ff",
-    iconColor: "#a855f7",
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#a855f7" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/>
-        <path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>
-      </svg>
-    ),
-  },
-  {
-    label: "Open Leads",
-    value: "61",
-    delta: "+14%",
-    up: true,
-    color: "#fffbeb",
-    iconColor: "#f59e0b",
-    icon: (
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-        <circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>
-      </svg>
-    ),
-  },
-];
- 
-const recentProperties = [
-  { id: 1, address: "Rr. Nënë Tereza 14, Prishtinë", type: "Apartment", status: "For Sale", price: "€145,000", agent: "Argjend M." },
-  { id: 2, address: "Rr. Dardania 5, Prizren", type: "House", status: "For Rent", price: "€450/mo", agent: "Vjosa K." },
-  { id: 3, address: "Rr. Adem Jashari 22, Mitrovicë", type: "Commercial", status: "For Sale", price: "€380,000", agent: "Blerim S." },
-  { id: 4, address: "Rr. Skënderbeu 8, Pejë", type: "Apartment", status: "Rented", price: "€320/mo", agent: "Argjend M." },
-  { id: 5, address: "Rr. UÇK 3, Gjakovë", type: "Land", status: "For Sale", price: "€95,000", agent: "Zana B." },
-];
- 
+import { useDashboardStats } from "../../hooks/usePropertyCache";
+
 const statusBadge = {
   "For Sale":  "badge badge--blue",
   "For Rent":  "badge badge--purple",
@@ -97,8 +8,112 @@ const statusBadge = {
   "Sold":      "badge badge--gray",
   "Pending":   "badge badge--amber",
 };
- 
+
+const recentProperties = [
+  { id: 1, address: "Rr. Nënë Tereza 14, Prishtinë", type: "Apartment", status: "For Sale", price: "€145,000", agent: "Argjend M." },
+  { id: 2, address: "Rr. Dardania 5, Prizren",        type: "House",     status: "For Rent", price: "€450/mo",  agent: "Vjosa K."   },
+  { id: 3, address: "Rr. Adem Jashari 22, Mitrovicë", type: "Commercial",status: "For Sale", price: "€380,000", agent: "Blerim S."  },
+  { id: 4, address: "Rr. Skënderbeu 8, Pejë",         type: "Apartment", status: "Rented",   price: "€320/mo",  agent: "Argjend M." },
+  { id: 5, address: "Rr. UÇK 3, Gjakovë",             type: "Land",      status: "For Sale", price: "€95,000",  agent: "Zana B."    },
+];
+
 export default function AdminDashboard() {
+  const { data: apiStats, isLoading } = useDashboardStats();
+
+  const stats = apiStats ? [
+    {
+      label: "Total Properties",
+      value: String(
+        (apiStats.available_properties ?? 0) +
+        (apiStats.sold_properties      ?? 0) +
+        (apiStats.rented_properties    ?? 0)
+      ),
+      delta: "+live", up: true,
+      color: "#eef2ff", iconColor: "#6366f1",
+      icon: (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+          stroke="#6366f1" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+          <polyline points="9 22 9 12 15 12 15 22"/>
+        </svg>
+      ),
+    },
+    {
+      label: "Active Leases",
+      value: String(apiStats.active_leases ?? 0),
+      delta: "live", up: true,
+      color: "#f0f9ff", iconColor: "#0ea5e9",
+      icon: (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+          stroke="#0ea5e9" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="7.5" cy="15.5" r="5.5"/>
+          <path d="M21 2 10.58 12.42M13 7l3 3M18 2l3 3-6 6-3-3"/>
+        </svg>
+      ),
+    },
+    {
+      label: "Overdue Payments",
+      value: String(apiStats.overdue_payments ?? 0),
+      delta: (apiStats.overdue_payments ?? 0) > 0 ? "⚠️" : "✓",
+      up:    (apiStats.overdue_payments ?? 0) === 0,
+      color: (apiStats.overdue_payments ?? 0) > 0 ? "#fef2f2" : "#ecfdf5",
+      iconColor: (apiStats.overdue_payments ?? 0) > 0 ? "#ef4444" : "#10b981",
+      icon: (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+          stroke={(apiStats.overdue_payments ?? 0) > 0 ? "#ef4444" : "#10b981"}
+          strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="12" y1="1" x2="12" y2="23"/>
+          <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
+        </svg>
+      ),
+    },
+    {
+      label: "Total Revenue",
+      value: `€${Number(apiStats.total_revenue ?? 0).toLocaleString("de-DE")}`,
+      delta: "PAID", up: true,
+      color: "#ecfdf5", iconColor: "#10b981",
+      icon: (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+          stroke="#10b981" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/>
+          <polyline points="17 6 23 6 23 12"/>
+        </svg>
+      ),
+    },
+    {
+      label: "Open Leads",
+      value: String(apiStats.pending_leads ?? 0),
+      delta: "NEW", up: true,
+      color: "#fffbeb", iconColor: "#f59e0b",
+      icon: (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+          stroke="#f59e0b" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10"/>
+          <circle cx="12" cy="12" r="6"/>
+          <circle cx="12" cy="12" r="2"/>
+        </svg>
+      ),
+    },
+  ] : [];
+
+  if (isLoading) {
+    return (
+      <MainLayout role="admin">
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+        <div style={{ textAlign: "center", padding: "60px 0" }}>
+          <div style={{
+            width: 32, height: 32, margin: "0 auto",
+            border: "3px solid #e8edf4", borderTop: "3px solid #6366f1",
+            borderRadius: "50%", animation: "spin 0.7s linear infinite",
+          }} />
+          <p style={{ color: "#94a3b8", marginTop: 12, fontSize: 13 }}>
+            Duke ngarkuar dashboard...
+          </p>
+        </div>
+      </MainLayout>
+    );
+  }
+
   return (
     <MainLayout role="admin">
       <div className="page-header">
@@ -111,7 +126,7 @@ export default function AdminDashboard() {
           <button className="btn btn--primary btn--sm">+ Add Property</button>
         </div>
       </div>
- 
+
       {/* Stats */}
       <div className="stat-grid">
         {stats.map((s) => (
@@ -131,7 +146,7 @@ export default function AdminDashboard() {
           </div>
         ))}
       </div>
- 
+
       {/* Recent Properties Table */}
       <div className="card">
         <div className="card__header">
@@ -155,7 +170,11 @@ export default function AdminDashboard() {
                 <tr key={p.id}>
                   <td style={{ fontWeight: 500 }}>{p.address}</td>
                   <td className="text-muted">{p.type}</td>
-                  <td><span className={statusBadge[p.status] || "badge badge--gray"}>{p.status}</span></td>
+                  <td>
+                    <span className={statusBadge[p.status] || "badge badge--gray"}>
+                      {p.status}
+                    </span>
+                  </td>
                   <td style={{ fontWeight: 500 }}>{p.price}</td>
                   <td className="text-muted">{p.agent}</td>
                   <td>


### PR DESCRIPTION
Implementon caching layer në frontend me React Query (@tanstack/react-query).

Ndryshimet kryesore:

1. React Query Setup (main.jsx)
   - QueryClientProvider me defaultOptions:
     staleTime: 5 min, gcTime: 10 min, retry: 1

2. usePropertyCache.js (hook i ri)
   - useProperties(page, size) — cache 5 min
   - useDashboardStats() — cache 10 min, sinkronizon me Redis backend
   - useUnreadCount() — cache 60 sek + auto-refetch

3. AdminDashboard.jsx
   - Zëvendëson 6 vlera hardcoded me të dhëna reale nga API
   - Tregon loader gjatë fetch
   - Stats: available+sold+rented properties, active leases,
     overdue payments, revenue, pending leads

Efekti: 10 admin që hapin dashboard → vetëm 1 query backend
(9 të tjerat i marrin nga React Query cache).

Kërkon: branch feature/admin-dashboard-stats-cache në backend të jetë merge-uar.

Closes #116 