### PR TITLE
[ADMIN AI] Add AI Contract Summary to Admin Contracts Page

### DIFF
--- a/src/pages/admin/Contracts.jsx
+++ b/src/pages/admin/Contracts.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import MainLayout from "../../components/layout/Layout";
 import api from "../../api/axios";
+import { AiContractSummaryButton } from "../shared/AiFeatures";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 const LEASE_STATUSES = ["ACTIVE", "ENDED", "CANCELLED", "PENDING_SIGNATURE"];
@@ -803,7 +804,7 @@ export default function AdminContracts() {
               <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 900 }}>
                 <thead>
                   <tr>
-                    {["#ID","Property","Listing","Client","Agent","Rent","Deposit","Start","End","Status","Created","Actions"]
+                    {["#ID","Property","Listing","Client","Agent","Rent","Deposit","Start","End","Status","Created","AI","Actions"]
                       .map(h => <th key={h} style={TH}>{h}</th>)}
                   </tr>
                 </thead>
@@ -844,6 +845,11 @@ export default function AdminContracts() {
                               </>
                             )}
                           </div>
+                        </td>
+
+                        {/* ── SHTO KËTË KOLONË TË RE ── */}
+                        <td style={TD}>
+                          <AiContractSummaryButton contract={c} />
                         </td>
                       </tr>
                     );


### PR DESCRIPTION
Integron AiContractSummaryButton nga PR #112 në
faqen AdminContracts.jsx.

Çfarë u shtua:
- Import i AiContractSummaryButton nga shared/AiFeatures
- Kolona e re "AI" në tabelën e kontratave
- Per çdo kontratë: buton "✨ AI Summary"
- Thirr POST /api/ai/contract/summary
- Modal me: summary, key dates, financial obligations,
  risks, status note

Pse ka kuptim për admin:
- Admini menaxhon kontratat ndër-tenant
- AI summary ndihmon të kuptojë shpejt gjendjen
  e çdo kontrate pa hapur Detail modal
- Konsistent me të njëjtën feature në AgentContracts

Nuk preket:
- Filtrat (client/agent/property/expiring)
- ContractFormModal, StatusModal, ContractDetailModal
- Logjika e fetch dhe pagination

Closes #130 