### PR TITLE
Invite links & invite-based registration

### DIFF
--- a/src/components/admin/agents/AgentsToolbar.jsx
+++ b/src/components/admin/agents/AgentsToolbar.jsx
@@ -1,33 +1,127 @@
+// src/components/admin/agents/AgentsToolbar.jsx
 
+import { useState, useContext } from "react";
+import { AuthContext } from "../../../context/AuthProvider";
+import api from "../../../api/axios";
+
+function InviteModal({ token, onClose }) {
+  const link = `${window.location.origin}/register?token=${token}`;
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(link).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    });
+  };
+
+  return (
+    <div className="aa-modal-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="aa-modal" style={{ maxWidth: 500 }}>
+        <div className="aa-modal-header">
+          <p className="aa-modal-title">Invite Agent</p>
+          <p className="aa-modal-sub">Link valid për 7 ditë · single-use</p>
+        </div>
+        <div className="aa-modal-body">
+          <div style={{ background: "rgba(56,189,248,0.07)", border: "1px solid rgba(56,189,248,0.18)", borderRadius: 10, padding: "12px 15px", marginBottom: 18, fontSize: 13, color: "rgba(245,240,232,0.65)", lineHeight: 1.6 }}>
+            <strong style={{ color: "#38bdf8" }}>ℹ️ Si funksionon</strong><br />
+            Agjenti hap këtë link, plotëson emrin, emailin dhe fjalëkalimin.
+            Llogaria e tij krijohet automatikisht në kompaninë tuaj si <strong>Agent</strong>.
+            Linku skadon pas <strong>7 ditëve</strong> ose pasi të përdoret.
+          </div>
+
+          <div style={{ marginBottom: 18 }}>
+            <p style={{ fontSize: 10.5, fontWeight: 600, letterSpacing: "0.8px", textTransform: "uppercase", color: "rgba(201,184,122,0.5)", marginBottom: 8 }}>
+              Invitation Link
+            </p>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <div style={{ flex: 1, padding: "10px 13px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(201,184,122,0.14)", borderRadius: 9, fontSize: 12, color: "rgba(245,240,232,0.6)", wordBreak: "break-all", fontFamily: "monospace" }}>
+                {link}
+              </div>
+              <button
+                onClick={handleCopy}
+                style={{ height: 40, padding: "0 16px", borderRadius: 9, border: copied ? "1px solid rgba(52,211,153,0.4)" : "1px solid rgba(201,184,122,0.25)", background: copied ? "rgba(52,211,153,0.1)" : "rgba(255,255,255,0.04)", color: copied ? "#34d399" : "#c9b87a", fontSize: 12.5, fontWeight: 600, fontFamily: "'DM Sans', sans-serif", cursor: "pointer", whiteSpace: "nowrap", transition: "all 0.2s", flexShrink: 0 }}
+              >
+                {copied ? "✓ Copied!" : "Copy Link"}
+              </button>
+            </div>
+          </div>
+
+          <div className="aa-modal-footer">
+            <button className="aa-btn-cancel" onClick={onClose}>Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function AgentsToolbar({ search, setSearch, filterActive, setFilterActive, count }) {
+  const { user }          = useContext(AuthContext);
+  const [token,     setToken]     = useState(null);
+  const [generating, setGenerating] = useState(false);
+  const [error,     setError]     = useState(null);
+
+  const handleInvite = async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      const res = await api.post("/api/invites", {
+        role:      "AGENT",
+        tenant_id: user.tenantId,
+      });
+      setToken(res.data.token);
+    } catch {
+      setError("Gabim gjatë gjenerimit të linkut");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
   return (
-    <div className="aa-toolbar">
-      <div className="aa-search">
-        <span className="aa-search-icon">
+    <>
+      <div className="aa-toolbar">
+        <div className="aa-search">
+          <span className="aa-search-icon">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+          </span>
+          <input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search by name, email or specialization..."
+          />
+        </div>
+        <button
+          className={`aa-filter-btn ${filterActive === true ? "active" : ""}`}
+          onClick={() => setFilterActive(p => p === true ? null : true)}
+        >
+          <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#34d399", display: "inline-block" }} /> Active
+        </button>
+        <button
+          className={`aa-filter-btn ${filterActive === false ? "active" : ""}`}
+          onClick={() => setFilterActive(p => p === false ? null : false)}
+        >
+          <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#f87171", display: "inline-block" }} /> Inactive
+        </button>
+        <span className="aa-count">{count} agent{count !== 1 ? "s" : ""}</span>
+
+        <button
+          onClick={handleInvite}
+          disabled={generating}
+          style={{ height: 40, padding: "0 18px", background: "linear-gradient(135deg,#c9b87a,#b0983e)", color: "#1a1714", border: "none", borderRadius: 10, fontSize: 13, fontWeight: 700, fontFamily: "'DM Sans',sans-serif", cursor: generating ? "not-allowed" : "pointer", display: "flex", alignItems: "center", gap: 7, transition: "all 0.17s", opacity: generating ? 0.6 : 1 }}
+        >
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
           </svg>
-        </span>
-        <input
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          placeholder="Search by name, email or specialization..."
-        />
+          {generating ? "Generating..." : "Invite Agent"}
+        </button>
+
+        {error && <span style={{ fontSize: 12, color: "#f87171" }}>{error}</span>}
       </div>
-      <button
-        className={`aa-filter-btn ${filterActive === true ? "active" : ""}`}
-        onClick={() => setFilterActive(p => p === true ? null : true)}
-      >
-        <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#34d399", display: "inline-block" }} /> Active
-      </button>
-      <button
-        className={`aa-filter-btn ${filterActive === false ? "active" : ""}`}
-        onClick={() => setFilterActive(p => p === false ? null : false)}
-      >
-        <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#f87171", display: "inline-block" }} /> Inactive
-      </button>
-      <span className="aa-count">{count} agent{count !== 1 ? "s" : ""}</span>
-    </div>
+
+      {token && <InviteModal token={token} onClose={() => setToken(null)} />}
+    </>
   );
 }

--- a/src/components/admin/clients/ClientsToolbar.jsx
+++ b/src/components/admin/clients/ClientsToolbar.jsx
@@ -1,33 +1,127 @@
-// src/components/admin/ClientsToolbar.jsx
+// src/components/admin/clients/ClientsToolbar.jsx
+
+import { useState, useContext } from "react";
+import { AuthContext } from "../../../context/AuthProvider";
+import api from "../../../api/axios";
+
+function InviteModal({ token, onClose }) {
+  const link = `${window.location.origin}/register?token=${token}`;
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(link).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    });
+  };
+
+  return (
+    <div className="ac-modal-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="ac-modal" style={{ maxWidth: 500 }}>
+        <div className="ac-modal-header">
+          <p className="ac-modal-title">Invite Client</p>
+          <p className="ac-modal-sub">Link valid për 7 ditë · single-use</p>
+        </div>
+        <div className="ac-modal-body">
+          <div style={{ background: "rgba(52,211,153,0.07)", border: "1px solid rgba(52,211,153,0.2)", borderRadius: 10, padding: "12px 15px", marginBottom: 18, fontSize: 13, color: "rgba(245,240,232,0.65)", lineHeight: 1.6 }}>
+            <strong style={{ color: "#34d399" }}>ℹ️ Si funksionon</strong><br />
+            Klienti hap këtë link, plotëson emrin, emailin dhe fjalëkalimin.
+            Llogaria e tij krijohet automatikisht në kompaninë tuaj si <strong>Client</strong>.
+            Linku skadon pas <strong>7 ditëve</strong> ose pasi të përdoret.
+          </div>
+
+          <div style={{ marginBottom: 18 }}>
+            <p style={{ fontSize: 10.5, fontWeight: 600, letterSpacing: "0.8px", textTransform: "uppercase", color: "rgba(201,184,122,0.5)", marginBottom: 8 }}>
+              Invitation Link
+            </p>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <div style={{ flex: 1, padding: "10px 13px", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(201,184,122,0.14)", borderRadius: 9, fontSize: 12, color: "rgba(245,240,232,0.6)", wordBreak: "break-all", fontFamily: "monospace" }}>
+                {link}
+              </div>
+              <button
+                onClick={handleCopy}
+                style={{ height: 40, padding: "0 16px", borderRadius: 9, border: copied ? "1px solid rgba(52,211,153,0.4)" : "1px solid rgba(52,211,153,0.25)", background: copied ? "rgba(52,211,153,0.1)" : "rgba(52,211,153,0.07)", color: "#34d399", fontSize: 12.5, fontWeight: 600, fontFamily: "'DM Sans',sans-serif", cursor: "pointer", whiteSpace: "nowrap", transition: "all 0.2s", flexShrink: 0 }}
+              >
+                {copied ? "✓ Copied!" : "Copy Link"}
+              </button>
+            </div>
+          </div>
+
+          <div className="ac-modal-footer">
+            <button className="ac-btn-cancel" onClick={onClose}>Close</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function ClientsToolbar({ search, setSearch, filterActive, setFilterActive, count }) {
+  const { user }            = useContext(AuthContext);
+  const [token,     setToken]     = useState(null);
+  const [generating, setGenerating] = useState(false);
+  const [error,     setError]     = useState(null);
+
+  const handleInvite = async () => {
+    setGenerating(true);
+    setError(null);
+    try {
+      const res = await api.post("/api/invites", {
+        role:      "CLIENT",
+        tenant_id: user.tenantId,
+      });
+      setToken(res.data.token);
+    } catch {
+      setError("Gabim gjatë gjenerimit të linkut");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
   return (
-    <div className="ac-toolbar">
-      <div className="ac-search">
-        <span className="ac-search-icon">
+    <>
+      <div className="ac-toolbar">
+        <div className="ac-search">
+          <span className="ac-search-icon">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            </svg>
+          </span>
+          <input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search by name, email or city..."
+          />
+        </div>
+        <button
+          className={`ac-filter-btn ${filterActive === true ? "active" : ""}`}
+          onClick={() => setFilterActive(p => p === true ? null : true)}
+        >
+          <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#34d399", display: "inline-block" }} /> Active
+        </button>
+        <button
+          className={`ac-filter-btn ${filterActive === false ? "active" : ""}`}
+          onClick={() => setFilterActive(p => p === false ? null : false)}
+        >
+          <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#f87171", display: "inline-block" }} /> Inactive
+        </button>
+        <span className="ac-count">{count} client{count !== 1 ? "s" : ""}</span>
+
+        <button
+          onClick={handleInvite}
+          disabled={generating}
+          style={{ height: 40, padding: "0 18px", background: "rgba(52,211,153,0.12)", color: "#34d399", border: "1px solid rgba(52,211,153,0.3)", borderRadius: 10, fontSize: 13, fontWeight: 700, fontFamily: "'DM Sans',sans-serif", cursor: generating ? "not-allowed" : "pointer", display: "flex", alignItems: "center", gap: 7, transition: "all 0.17s", opacity: generating ? 0.6 : 1 }}
+        >
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
           </svg>
-        </span>
-        <input
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          placeholder="Search by name, email or city..."
-        />
+          {generating ? "Generating..." : "Invite Client"}
+        </button>
+
+        {error && <span style={{ fontSize: 12, color: "#f87171" }}>{error}</span>}
       </div>
-      <button
-        className={`ac-filter-btn ${filterActive === true ? "active" : ""}`}
-        onClick={() => setFilterActive(p => p === true ? null : true)}
-      >
-        <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#34d399", display: "inline-block" }} /> Active
-      </button>
-      <button
-        className={`ac-filter-btn ${filterActive === false ? "active" : ""}`}
-        onClick={() => setFilterActive(p => p === false ? null : false)}
-      >
-        <span style={{ width: 6, height: 6, borderRadius: "50%", background: "#f87171", display: "inline-block" }} /> Inactive
-      </button>
-      <span className="ac-count">{count} client{count !== 1 ? "s" : ""}</span>
-    </div>
+
+      {token && <InviteModal token={token} onClose={() => setToken(null)} />}
+    </>
   );
 }

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -15,23 +15,27 @@ export default function AuthProvider({ children }) {
     });
 
     const [loading, setLoading] = useState(false);
-    const [error, setError] = useState(null);
+    const [error,   setError]   = useState(null);
 
     // ───────── LOGIN ─────────
     const login = async (email, password) => {
         setLoading(true);
         setError(null);
         try {
-            const res = await api.post("/api/auth/login", { email, password });
+            const res  = await api.post("/api/auth/login", { email, password });
             const data = res.data;
+
+            // schema_name = "tenant_rose_1" → e ruajmë si tenantSlug
             const userInfo = {
-                id: data.user_id,
-                email: data.email,
-                fullName: data.full_name,
-                role: data.role?.toLowerCase(),
-                tenantId: data.tenant_id,
+                id:         data.user_id,
+                email:      data.email,
+                fullName:   data.full_name,
+                role:       data.role?.toLowerCase(),
+                tenantId:   data.tenant_id,
                 tenantName: data.tenant_name,
+                tenantSlug: data.schema_name,   // ← e shtova
             };
+
             localStorage.setItem("access_token", data.access_token);
             localStorage.setItem("refresh_token", data.refresh_token);
             localStorage.setItem("user_info", JSON.stringify(userInfo));
@@ -51,13 +55,14 @@ export default function AuthProvider({ children }) {
         setError(null);
         try {
             const payload = {
-                email: form.email,
-                password: form.password,
-                firstName: form.firstName,
-                lastName: form.lastName,
-                role: form.role,
+                email:      form.email,
+                password:   form.password,
+                firstName:  form.firstName,
+                lastName:   form.lastName,
+                role:       form.role,
                 tenantSlug: form.tenantSlug,
                 tenantName: form.tenantName,
+                inviteToken: form.inviteToken || null,
             };
             const res = await api.post("/api/auth/register", payload);
             return res.data;
@@ -73,9 +78,7 @@ export default function AuthProvider({ children }) {
     const logout = async () => {
         try {
             const refreshToken = localStorage.getItem("refresh_token");
-            if (refreshToken) {
-                await api.post("/api/auth/logout", { refreshToken });
-            }
+            if (refreshToken) await api.post("/api/auth/logout", { refreshToken });
         } catch (_) {}
         localStorage.removeItem("access_token");
         localStorage.removeItem("refresh_token");
@@ -92,8 +95,8 @@ export default function AuthProvider({ children }) {
     const refreshToken = async () => {
         try {
             const token = localStorage.getItem("refresh_token");
-            const res = await api.post("/api/auth/refresh", { refreshToken: token });
-            localStorage.setItem("access_token", res.data.access_token);
+            const res   = await api.post("/api/auth/refresh", { refreshToken: token });
+            localStorage.setItem("access_token",  res.data.access_token);
             localStorage.setItem("refresh_token", res.data.refresh_token);
             return res.data;
         } catch (err) {
@@ -112,12 +115,13 @@ export default function AuthProvider({ children }) {
 
             localStorage.setItem("access_token", data.token);
 
-           const impersonatedUser = {
-    id:       userId,
-    email:    data.email,
-    role:     data.role?.toLowerCase(),
-    fullName: data.full_name || data.email?.split("@")[0],
-};
+            const impersonatedUser = {
+                id:       userId,
+                email:    data.email,
+                role:     data.role?.toLowerCase(),
+                fullName: data.full_name || data.email?.split("@")[0],
+            };
+
             localStorage.setItem("user_info",     JSON.stringify(impersonatedUser));
             localStorage.setItem("impersonating", JSON.stringify({
                 email: data.email,
@@ -127,7 +131,6 @@ export default function AuthProvider({ children }) {
             setUser(impersonatedUser);
             setImpersonating({ email: data.email, role: data.role });
 
-            // Navigate te dashboard i rolerit
             const role = data.role?.toLowerCase();
             if (role === "agent")       window.location.href = "/agent";
             else if (role === "client") window.location.href = "/client/clientdashboard";
@@ -139,9 +142,7 @@ export default function AuthProvider({ children }) {
     };
 
     const exitImpersonation = async () => {
-        try {
-            await api.post("/api/admin/impersonate/exit");
-        } catch (_) {}
+        try { await api.post("/api/admin/impersonate/exit"); } catch (_) {}
 
         const adminToken    = localStorage.getItem("admin_token");
         const adminUserInfo = localStorage.getItem("admin_user_info");
@@ -155,27 +156,23 @@ export default function AuthProvider({ children }) {
 
         setUser(JSON.parse(adminUserInfo));
         setImpersonating(null);
-
-        // Navigate te dashboard i adminit
         window.location.href = "/admin";
     };
 
     return (
-        <AuthContext.Provider
-            value={{
-                user,
-                login,
-                register,
-                logout,
-                refreshToken,
-                loading,
-                error,
-                isAuthenticated: !!user,
-                impersonating,
-                startImpersonation,
-                exitImpersonation,
-            }}
-        >
+        <AuthContext.Provider value={{
+            user,
+            login,
+            register,
+            logout,
+            refreshToken,
+            loading,
+            error,
+            isAuthenticated: !!user,
+            impersonating,
+            startImpersonation,
+            exitImpersonation,
+        }}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/pages/admin/AdminAllAgents.jsx
+++ b/src/pages/admin/AdminAllAgents.jsx
@@ -4,15 +4,15 @@ import { AuthContext } from "../../context/AuthProvider";
 import api from "../../api/axios";
 
 import "../../styles/admin/AdminAllAgents.css";
-import AgentsStats          from "../../components/admin/agents/AgentsStats";
-import AgentsToolbar        from "../../components/admin/agents/AgentsToolbar";
-import AgentsTable          from "../../components/admin/agents/AgentsTable";
-import AgentViewModal       from "../../components/admin/agents/AgentViewModal";
+import AgentsStats           from "../../components/admin/agents/AgentsStats";
+import AgentsToolbar         from "../../components/admin/agents/AgentsToolbar";
+import AgentsTable           from "../../components/admin/agents/AgentsTable";
+import AgentViewModal        from "../../components/admin/agents/AgentViewModal";
 import AgentImpersonateModal from "../../components/admin/agents/AgentImpersonateModal";
-import { getFullName }      from "../../components/admin/agents/agentsHelpers";
+import { getFullName }       from "../../components/admin/agents/agentsHelpers";
 
 export default function AdminAllAgents() {
-  const { startImpersonation } = useContext(AuthContext);
+  const { user, startImpersonation } = useContext(AuthContext);
 
   const [agents,        setAgents]        = useState([]);
   const [loading,       setLoading]       = useState(true);
@@ -123,6 +123,7 @@ export default function AdminAllAgents() {
           filterActive={filterActive}
           setFilterActive={setFilterActive}
           count={filtered.length}
+          tenantSlug={user?.tenantSlug}
         />
 
         <div className="aa-table-wrap">

--- a/src/pages/admin/AdminAllClients.jsx
+++ b/src/pages/admin/AdminAllClients.jsx
@@ -12,7 +12,7 @@ import ClientImpersonateModal from "../../components/admin/clients/ClientImperso
 import { getFullName }        from "../../components/admin/clients/clientsHelpers";
 
 export default function AdminAllClients() {
-  const { startImpersonation } = useContext(AuthContext);
+  const { user, startImpersonation } = useContext(AuthContext);
 
   const [clients,       setClients]       = useState([]);
   const [loading,       setLoading]       = useState(true);
@@ -119,6 +119,7 @@ export default function AdminAllClients() {
           filterActive={filterActive}
           setFilterActive={setFilterActive}
           count={filtered.length}
+          tenantSlug={user?.tenantSlug}
         />
 
         <div className="ac-table-wrap">

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -599,17 +599,7 @@ export default function Login() {
               ) : "Sign In →"}
             </button>
 
-            {/* Divider */}
-            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-              <div style={{ flex: 1, height: 1, background: "#e8e0d0" }} />
-              <span style={{ fontSize: 12, color: "#b0a88e" }}>or</span>
-              <div style={{ flex: 1, height: 1, background: "#e8e0d0" }} />
-            </div>
-
-            {/* Register link */}
-            <Link to="/register" className="register-btn">
-              Don't have an account? <strong style={{ color: "#3d3828" }}>Create one</strong>
-            </Link>
+          
           </div>
 
           {/* Footer */}

--- a/src/pages/auth/Register.jsx
+++ b/src/pages/auth/Register.jsx
@@ -1,76 +1,51 @@
 import { useState, useContext, useEffect } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useSearchParams } from "react-router-dom";
 import { AuthContext } from "../../context/AuthProvider";
+import api from "../../api/axios";
 
-// ─── Slideshow images (same set as Login) ─────────────────────────────────────
 const SLIDES = [
-  {
-    url: "https://images.unsplash.com/photo-1613490493576-7fde63acd811?w=1400&q=90",
-    label: "Luxury Villa",
-    location: "Sarandë, Albania",
-    price: "€420,000",
-    tag: "For Sale",
-  },
-  {
-    url: "https://images.unsplash.com/photo-1512917774080-9991f1c4c750?w=1400&q=90",
-    label: "Modern Penthouse",
-    location: "Tirana, Albania",
-    price: "€320,000",
-    tag: "New Listing",
-  },
-  {
-    url: "https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=1400&q=90",
-    label: "Seaside Retreat",
-    location: "Vlorë, Albania",
-    price: "€185,000",
-    tag: "Hot Deal",
-  },
-  {
-    url: "https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1400&q=90",
-    label: "Country Estate",
-    location: "Shkodër, Albania",
-    price: "€270,000",
-    tag: "For Sale",
-  },
-  {
-    url: "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?w=1400&q=90",
-    label: "Private Pool Villa",
-    location: "Durrës, Albania",
-    price: "€510,000",
-    tag: "Premium",
-  },
+  { url: "https://images.unsplash.com/photo-1613490493576-7fde63acd811?w=1400&q=90", label: "Luxury Villa",      location: "Sarandë, Albania", price: "€420,000", tag: "For Sale"    },
+  { url: "https://images.unsplash.com/photo-1512917774080-9991f1c4c750?w=1400&q=90", label: "Modern Penthouse",  location: "Tirana, Albania",   price: "€320,000", tag: "New Listing" },
+  { url: "https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=1400&q=90", label: "Seaside Retreat",   location: "Vlorë, Albania",    price: "€185,000", tag: "Hot Deal"    },
+  { url: "https://images.unsplash.com/photo-1600585154340-be6161a56a0c?w=1400&q=90", label: "Country Estate",    location: "Shkodër, Albania",  price: "€270,000", tag: "For Sale"    },
+  { url: "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?w=1400&q=90", label: "Private Pool Villa", location: "Durrës, Albania",   price: "€510,000", tag: "Premium"     },
 ];
 
-// ─── Role options ─────────────────────────────────────────────────────────────
 const ROLES = [
-  { value: "client", label: "Client",  icon: "👤", desc: "Browse & inquire about properties" },
-  { value: "agent",  label: "Agent",   icon: "🤝", desc: "List and manage properties" },
-  { value: "admin",  label: "Admin",   icon: "⚙️",  desc: "Full platform access" },
+  { value: "client", label: "Client", icon: "👤", desc: "Browse & inquire about properties" },
+  { value: "agent",  label: "Agent",  icon: "🤝", desc: "List and manage properties"        },
+  { value: "admin",  label: "Admin",  icon: "⚙️",  desc: "Full platform access"              },
 ];
 
-// ─── Tag pill ─────────────────────────────────────────────────────────────────
 function TagPill({ label }) {
   const colors = {
-    "For Sale":    { bg: "rgba(255,255,255,0.12)", color: "#fff" },
+    "For Sale":    { bg: "rgba(255,255,255,0.12)", color: "#fff"    },
     "New Listing": { bg: "rgba(100,200,120,0.25)", color: "#7ee89a" },
     "Hot Deal":    { bg: "rgba(255,140,80,0.25)",  color: "#ffb07c" },
     "Premium":     { bg: "rgba(200,170,80,0.25)",  color: "#e2c97e" },
   };
   const c = colors[label] || colors["For Sale"];
   return (
-    <span style={{
-      display: "inline-block", padding: "4px 12px", borderRadius: 999,
-      fontSize: 11, fontWeight: 700, letterSpacing: "0.5px", textTransform: "uppercase",
-      background: c.bg, color: c.color, border: `1px solid ${c.color}33`,
-    }}>{label}</span>
+    <span style={{ display:"inline-block", padding:"4px 12px", borderRadius:999, fontSize:11, fontWeight:700, letterSpacing:"0.5px", textTransform:"uppercase", background:c.bg, color:c.color, border:`1px solid ${c.color}33` }}>
+      {label}
+    </span>
   );
 }
 
-// ─── Main Register Component ──────────────────────────────────────────────────
 export default function Register() {
-  const { register } = useContext(AuthContext);
-  const navigate = useNavigate();
+  const { register }   = useContext(AuthContext);
+  const navigate       = useNavigate();
+  const [searchParams] = useSearchParams();
 
+  const urlToken  = searchParams.get("token") || "";
+  const isInvited = !!urlToken;
+
+  // Të dhënat e invitation (nga backend)
+  const [inviteData,    setInviteData]    = useState(null); // { tenant_slug, tenant_name, role }
+  const [inviteLoading, setInviteLoading] = useState(isInvited);
+  const [inviteError,   setInviteError]   = useState("");
+
+  // Form state
   const [firstName,   setFirstName]   = useState("");
   const [lastName,    setLastName]    = useState("");
   const [companyName, setCompanyName] = useState("");
@@ -83,525 +58,296 @@ export default function Register() {
   const [mounted,     setMounted]     = useState(false);
   const [slide,       setSlide]       = useState(0);
 
+  useEffect(() => { const t = setTimeout(() => setMounted(true), 60); return () => clearTimeout(t); }, []);
   useEffect(() => {
-    const t = setTimeout(() => setMounted(true), 60);
-    return () => clearTimeout(t);
+    const iv = setInterval(() => setSlide(s => (s + 1) % SLIDES.length), 3000);
+    return () => clearInterval(iv);
   }, []);
 
+  // ── Verifiko token-in me backend ─────────────────────────────────────────
   useEffect(() => {
-    const interval = setInterval(() => {
-      setSlide(s => (s + 1) % SLIDES.length);
-    }, 3000);
-    return () => clearInterval(interval);
-  }, []);
+    if (!isInvited) return;
+    api.get(`/api/invites/${urlToken}`)
+      .then(res => {
+        setInviteData(res.data);
+        setRole(res.data.role.toLowerCase());
+      })
+      .catch(() => {
+        setInviteError("Ky link invitation është i pavlefshëm ose ka skaduar.");
+      })
+      .finally(() => setInviteLoading(false));
+  }, [urlToken, isInvited]);
 
-  const generateSlug = (name) =>
+  const generateSlug = name =>
     name.toLowerCase().trim()
-      .replace(/\s+/g, "-")
-      .replace(/[^a-z0-9-]/g, "")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "");
+      .replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "")
+      .replace(/-+/g, "-").replace(/^-|-$/g, "");
 
   const handleRegister = async () => {
-    if (!firstName || !lastName || !email || !password || !companyName) {
-      setError("Please fill in all fields.");
+    if (!firstName || !lastName || !email || !password) {
+      setError("Please fill in all required fields."); return;
+    }
+    if (!isInvited && !companyName) {
+      setError("Please enter your company name."); return;
+    }
+
+    setError(""); setLoading(true);
+
+    const res = await register({
+      email,
+      password,
+      firstName,
+      lastName,
+      role,
+      tenantSlug: isInvited ? inviteData.tenant_slug : generateSlug(companyName),
+      tenantName: isInvited ? inviteData.tenant_name : companyName,
+      inviteToken: isInvited ? urlToken : null,
+    });
+
+    if (!res) {
+      setLoading(false);
+      setError("Registration failed. Please try again.");
       return;
     }
-    setError(""); setLoading(true);
-    const res = await register({
-      email, password, firstName, lastName, role,
-      tenantSlug: generateSlug(companyName),
-      tenantName: companyName,
-    });
+
+    // Shëno token-in si të përdorur
+    if (isInvited) {
+      await api.patch(`/api/invites/${urlToken}/use`).catch(() => {});
+    }
+
     setLoading(false);
-    if (!res) { setError("Registration failed. Please try again."); return; }
-    if (role === "admin")      navigate("/");
-    else if (role === "agent") navigate("/");
-    else navigate("/");
+    navigate("/");
   };
 
-  const current = SLIDES[slide];
+  const current   = SLIDES[slide];
+  const roleLabel = ROLES.find(r => r.value === role)?.label || role;
 
   return (
     <>
       <style>{`
         @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;600;700&family=DM+Sans:wght@300;400;500;600&display=swap');
-
         * { box-sizing: border-box; }
+        @keyframes fadeIn       { from{opacity:0} to{opacity:1} }
+        @keyframes slideInRight { from{opacity:0;transform:translateX(36px)} to{opacity:1;transform:translateX(0)} }
+        @keyframes spin         { to{transform:rotate(360deg)} }
+        @keyframes pulseDot     { 0%,100%{transform:scale(1);opacity:1} 50%{transform:scale(1.4);opacity:.7} }
 
-        @keyframes fadeIn {
-          from { opacity: 0; } to { opacity: 1; }
-        }
-        @keyframes slideInRight {
-          from { opacity: 0; transform: translateX(36px); }
-          to   { opacity: 1; transform: translateX(0); }
-        }
-        @keyframes slideUp {
-          from { opacity: 0; transform: translateY(20px); }
-          to   { opacity: 1; transform: translateY(0); }
-        }
-        @keyframes spin {
-          to { transform: rotate(360deg); }
-        }
-        @keyframes pulseDot {
-          0%, 100% { transform: scale(1); opacity: 1; }
-          50%       { transform: scale(1.4); opacity: 0.7; }
-        }
-
-        .reg-input {
-          width: 100%;
-          padding: 10px 14px;
-          border: 1.5px solid #e4ddd0;
-          border-radius: 11px;
-          font-size: 13px;
-          color: #1a1714;
-          background: #fcfaf7;
-          font-family: 'DM Sans', sans-serif;
-          transition: all 0.2s;
-          appearance: none;
-        }
-        .reg-input::placeholder { color: #b8b0a0; }
-        .reg-input:focus {
-          border-color: #8a7d5e;
-          box-shadow: 0 0 0 4px rgba(138,125,94,0.12);
-          outline: none;
-          background: #fff;
-        }
-
-        .role-card {
-          display: flex;
-          align-items: center;
-          gap: 12px;
-          padding: 9px 11px;
-          border: 1.5px solid #e4ddd0;
-          border-radius: 11px;
-          cursor: pointer;
-          transition: all 0.18s;
-          background: #fcfaf7;
-          flex: 1;
-        }
-        .role-card:hover {
-          border-color: #8a7d5e;
-          background: #f5f0e8;
-        }
-        .role-card.selected {
-          border-color: #1a1714;
-          background: #1a1714;
-        }
-
-        .reg-btn {
-          width: 100%;
-          padding: 12px;
-          background: linear-gradient(135deg, #1a1714 0%, #2e2a22 100%);
-          color: #e8dfc8;
-          border: none;
-          border-radius: 12px;
-          font-size: 14px;
-          font-weight: 600;
-          cursor: pointer;
-          font-family: 'DM Sans', sans-serif;
-          letter-spacing: 0.3px;
-          transition: all 0.22s;
-          box-shadow: 0 4px 20px rgba(26,23,20,0.28);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 8px;
-        }
-        .reg-btn:hover:not(:disabled) {
-          background: linear-gradient(135deg, #2e2a22 0%, #45402f 100%);
-          transform: translateY(-2px);
-          box-shadow: 0 8px 28px rgba(26,23,20,0.35);
-        }
-        .reg-btn:disabled { opacity: 0.65; cursor: not-allowed; }
-
-        .login-link-btn {
-          width: 100%;
-          padding: 11px;
-          border: 1.5px solid #e4ddd0;
-          border-radius: 12px;
-          background: transparent;
-          font-size: 13.5px;
-          font-weight: 500;
-          color: #6b6248;
-          cursor: pointer;
-          font-family: 'DM Sans', sans-serif;
-          text-align: center;
-          text-decoration: none;
-          display: block;
-          transition: all 0.2s;
-        }
-        .login-link-btn:hover {
-          border-color: #8a7d5e;
-          color: #1a1714;
-          background: #f8f4ed;
-        }
-
-        .dot-btn {
-          border: none; cursor: pointer; padding: 0;
-          transition: all 0.3s; border-radius: 4px;
-        }
-
-        .slide-img {
-          position: absolute; inset: 0;
-          width: 100%; height: 100%;
-          object-fit: cover;
-          transition: opacity 0.7s ease;
-        }
+        .reg-input { width:100%; padding:10px 14px; border:1.5px solid #e4ddd0; border-radius:11px; font-size:13px; color:#1a1714; background:#fcfaf7; font-family:'DM Sans',sans-serif; transition:all .2s; appearance:none; }
+        .reg-input::placeholder { color:#b8b0a0; }
+        .reg-input:focus { border-color:#8a7d5e; box-shadow:0 0 0 4px rgba(138,125,94,.12); outline:none; background:#fff; }
+        .role-card { display:flex; align-items:center; gap:12px; padding:9px 11px; border:1.5px solid #e4ddd0; border-radius:11px; cursor:pointer; transition:all .18s; background:#fcfaf7; flex:1; }
+        .role-card:hover    { border-color:#8a7d5e; background:#f5f0e8; }
+        .role-card.selected { border-color:#1a1714; background:#1a1714; }
+        .reg-btn { width:100%; padding:12px; background:linear-gradient(135deg,#1a1714 0%,#2e2a22 100%); color:#e8dfc8; border:none; border-radius:12px; font-size:14px; font-weight:600; cursor:pointer; font-family:'DM Sans',sans-serif; transition:all .22s; box-shadow:0 4px 20px rgba(26,23,20,.28); display:flex; align-items:center; justify-content:center; gap:8px; }
+        .reg-btn:hover:not(:disabled) { background:linear-gradient(135deg,#2e2a22 0%,#45402f 100%); transform:translateY(-2px); box-shadow:0 8px 28px rgba(26,23,20,.35); }
+        .reg-btn:disabled { opacity:.65; cursor:not-allowed; }
+        .login-link-btn { width:100%; padding:11px; border:1.5px solid #e4ddd0; border-radius:12px; background:transparent; font-size:13.5px; font-weight:500; color:#6b6248; cursor:pointer; font-family:'DM Sans',sans-serif; text-align:center; text-decoration:none; display:block; transition:all .2s; }
+        .login-link-btn:hover { border-color:#8a7d5e; color:#1a1714; background:#f8f4ed; }
+        .dot-btn   { border:none; cursor:pointer; padding:0; transition:all .3s; border-radius:4px; }
+        .slide-img { position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
       `}</style>
 
-      <div style={{
-        display: "flex",
-        minHeight: "100vh",
-        fontFamily: "'DM Sans', system-ui, sans-serif",
-        overflow: "hidden",
-        background: "#f5f0e8",
-      }}>
+      <div style={{ display:"flex", minHeight:"100vh", fontFamily:"'DM Sans',system-ui,sans-serif", overflow:"hidden", background:"#f5f0e8" }}>
 
-        {/* ── LEFT PANEL — slideshow ── */}
-        <div style={{
-          flex: "1 1 55%",
-          position: "relative",
-          overflow: "hidden",
-          minHeight: "100vh",
-        }}>
-          <img
-            key={slide}
-            src={current.url}
-            alt={current.label}
-            className="slide-img"
-            style={{ opacity: 1, zIndex: 2, animation: "fadeIn 0.7s ease forwards" }}
-          />
+        {/* ── LEFT PANEL ── */}
+        <div style={{ flex:"1 1 55%", position:"relative", overflow:"hidden", minHeight:"100vh" }}>
+          <img key={slide} src={current.url} alt={current.label} className="slide-img" style={{ zIndex:2, animation:"fadeIn .7s ease forwards" }} />
+          <div style={{ position:"absolute", inset:0, zIndex:3, background:"linear-gradient(to right,rgba(0,0,0,.55) 0%,rgba(0,0,0,.1) 60%,transparent 100%)" }} />
+          <div style={{ position:"absolute", inset:0, zIndex:3, background:"linear-gradient(to top,rgba(0,0,0,.72) 0%,transparent 50%)" }} />
 
-          {/* Overlays */}
-          <div style={{
-            position: "absolute", inset: 0, zIndex: 3,
-            background: "linear-gradient(to right, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0.1) 60%, transparent 100%)",
-          }} />
-          <div style={{
-            position: "absolute", inset: 0, zIndex: 3,
-            background: "linear-gradient(to top, rgba(0,0,0,0.72) 0%, transparent 50%)",
-          }} />
-
-          {/* Logo */}
-          <div style={{
-            position: "absolute", top: 40, left: 48, zIndex: 10,
-            display: "flex", alignItems: "center", gap: 12,
-            opacity: mounted ? 1 : 0,
-            animation: mounted ? "fadeIn 0.6s ease forwards" : "none",
-          }}>
-            <div style={{
-              width: 42, height: 42, borderRadius: 11,
-              background: "rgba(255,255,255,0.15)",
-              border: "1px solid rgba(255,255,255,0.25)",
-              backdropFilter: "blur(10px)",
-              display: "flex", alignItems: "center", justifyContent: "center",
-              fontSize: 20,
-            }}>🏡</div>
-            <span style={{ fontSize: 19, fontWeight: 600, color: "#fff", letterSpacing: "-0.2px" }}>
-              PropManager
-            </span>
+          <div style={{ position:"absolute", top:40, left:48, zIndex:10, display:"flex", alignItems:"center", gap:12, opacity:mounted?1:0, animation:mounted?"fadeIn .6s ease forwards":"none" }}>
+            <div style={{ width:42, height:42, borderRadius:11, background:"rgba(255,255,255,.15)", border:"1px solid rgba(255,255,255,.25)", backdropFilter:"blur(10px)", display:"flex", alignItems:"center", justifyContent:"center", fontSize:20 }}>🏡</div>
+            <span style={{ fontSize:19, fontWeight:600, color:"#fff", letterSpacing:"-0.2px" }}>PropManager</span>
           </div>
 
-          {/* Live badge */}
-          <div style={{
-            position: "absolute", top: 44, right: 24, zIndex: 10,
-            display: "flex", alignItems: "center", gap: 7,
-            background: "rgba(0,0,0,0.4)", backdropFilter: "blur(10px)",
-            border: "1px solid rgba(255,255,255,0.1)",
-            borderRadius: 999, padding: "6px 14px",
-            opacity: mounted ? 1 : 0,
-            animation: mounted ? "fadeIn 0.8s ease 0.4s forwards" : "none",
-          }}>
-            <div style={{
-              width: 8, height: 8, borderRadius: "50%",
-              background: "#4ade80",
-              animation: "pulseDot 1.8s ease infinite",
-            }} />
-            <span style={{ fontSize: 11.5, color: "rgba(255,255,255,0.8)", fontWeight: 500 }}>
-              Join 840+ clients today
-            </span>
+          <div style={{ position:"absolute", top:44, right:24, zIndex:10, display:"flex", alignItems:"center", gap:7, background:"rgba(0,0,0,.4)", backdropFilter:"blur(10px)", border:"1px solid rgba(255,255,255,.1)", borderRadius:999, padding:"6px 14px", opacity:mounted?1:0, animation:mounted?"fadeIn .8s ease .4s forwards":"none" }}>
+            <div style={{ width:8, height:8, borderRadius:"50%", background:"#4ade80", animation:"pulseDot 1.8s ease infinite" }} />
+            <span style={{ fontSize:11.5, color:"rgba(255,255,255,.8)", fontWeight:500 }}>Join 840+ clients today</span>
           </div>
 
-          {/* Centered hero text */}
-          <div style={{
-            position: "absolute",
-            top: "50%", left: 48,
-            transform: "translateY(-50%)",
-            zIndex: 10,
-            maxWidth: 440,
-          }}>
-            <p style={{
-              fontSize: 11, fontWeight: 600, color: "rgba(255,255,255,0.5)",
-              textTransform: "uppercase", letterSpacing: "2px", margin: "0 0 14px",
-            }}>Start your journey</p>
-            <h1 style={{
-              fontFamily: "'Cormorant Garamond', Georgia, serif",
-              fontSize: "clamp(38px, 4vw, 58px)",
-              fontWeight: 700, color: "#fff",
-              margin: "0 0 16px", lineHeight: 1.1, letterSpacing: "-0.5px",
-            }}>
-              Your dream<br />
-              <span style={{ color: "#e2c97e" }}>property awaits.</span>
+          <div style={{ position:"absolute", top:"50%", left:48, transform:"translateY(-50%)", zIndex:10, maxWidth:440 }}>
+            <p style={{ fontSize:11, fontWeight:600, color:"rgba(255,255,255,.5)", textTransform:"uppercase", letterSpacing:"2px", margin:"0 0 14px" }}>Start your journey</p>
+            <h1 style={{ fontFamily:"'Cormorant Garamond',Georgia,serif", fontSize:"clamp(38px,4vw,58px)", fontWeight:700, color:"#fff", margin:"0 0 16px", lineHeight:1.1, letterSpacing:"-0.5px" }}>
+              Your dream<br /><span style={{ color:"#e2c97e" }}>property awaits.</span>
             </h1>
-            <p style={{
-              fontSize: 14, color: "rgba(255,255,255,0.6)", lineHeight: 1.7, margin: 0,
-            }}>
+            <p style={{ fontSize:14, color:"rgba(255,255,255,.6)", lineHeight:1.7, margin:0 }}>
               Create your account and get instant access to thousands of verified listings across Albania.
             </p>
           </div>
 
-          {/* Bottom property info */}
-          <div style={{
-            position: "absolute", bottom: 0, left: 0, right: 0,
-            zIndex: 10, padding: "36px 48px",
-          }}>
-            <div style={{ marginBottom: 10 }}>
-              <TagPill label={current.tag} />
+          <div style={{ position:"absolute", bottom:0, left:0, right:0, zIndex:10, padding:"36px 48px" }}>
+            <div style={{ marginBottom:10 }}><TagPill label={current.tag} /></div>
+            <h2 style={{ fontFamily:"'Cormorant Garamond',Georgia,serif", fontSize:"clamp(22px,2.5vw,32px)", fontWeight:700, color:"#fff", margin:"0 0 6px", letterSpacing:"-0.3px", lineHeight:1.1 }}>{current.label}</h2>
+            <div style={{ display:"flex", alignItems:"center", gap:20, marginBottom:22 }}>
+              <span style={{ fontSize:13, color:"rgba(255,255,255,.55)" }}>📍 {current.location}</span>
+              <span style={{ fontSize:18, fontWeight:700, color:"#e2c97e", fontFamily:"'Cormorant Garamond',serif" }}>{current.price}</span>
             </div>
-            <h2 style={{
-              fontFamily: "'Cormorant Garamond', Georgia, serif",
-              fontSize: "clamp(22px, 2.5vw, 32px)",
-              fontWeight: 700, color: "#fff",
-              margin: "0 0 6px", letterSpacing: "-0.3px", lineHeight: 1.1,
-            }}>{current.label}</h2>
-            <div style={{ display: "flex", alignItems: "center", gap: 20, marginBottom: 22 }}>
-              <span style={{ fontSize: 13, color: "rgba(255,255,255,0.55)" }}>📍 {current.location}</span>
-              <span style={{
-                fontSize: 18, fontWeight: 700, color: "#e2c97e",
-                fontFamily: "'Cormorant Garamond', serif",
-              }}>{current.price}</span>
-            </div>
-
-            {/* Dots */}
-            <div style={{ display: "flex", gap: 7, alignItems: "center" }}>
+            <div style={{ display:"flex", gap:7, alignItems:"center" }}>
               {SLIDES.map((_, i) => (
-                <button key={i} className="dot-btn" onClick={() => setSlide(i)} style={{
-                  width: i === slide ? 22 : 7,
-                  height: 7,
-                  background: i === slide ? "#e2c97e" : "rgba(255,255,255,0.35)",
-                  borderRadius: i === slide ? 4 : "50%",
-                }} />
+                <button key={i} className="dot-btn" onClick={() => setSlide(i)}
+                  style={{ width:i===slide?22:7, height:7, background:i===slide?"#e2c97e":"rgba(255,255,255,.35)", borderRadius:i===slide?4:"50%" }} />
               ))}
             </div>
           </div>
         </div>
 
-        {/* ── RIGHT PANEL — register form ── */}
-        <div style={{
-          flex: "0 0 460px",
-          background: "#faf7f2",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          padding: "32px 44px",
-          position: "relative",
-          overflowY: "auto",
-          opacity: mounted ? 1 : 0,
-          animation: mounted ? "slideInRight 0.7s ease 0.2s forwards" : "none",
-          boxShadow: "-24px 0 80px rgba(0,0,0,0.08)",
-          zIndex: 20,
-        }}>
-          {/* Accent line */}
-          <div style={{
-            position: "absolute", top: 0, left: 0, right: 0, height: 3,
-            background: "linear-gradient(90deg, #1a1714, #8a7d5e, #c9b87a, #8a7d5e, #1a1714)",
-          }} />
+        {/* ── RIGHT PANEL ── */}
+        <div style={{ flex:"0 0 460px", background:"#faf7f2", display:"flex", flexDirection:"column", justifyContent:"center", padding:"32px 44px", position:"relative", overflowY:"auto", opacity:mounted?1:0, animation:mounted?"slideInRight .7s ease .2s forwards":"none", boxShadow:"-24px 0 80px rgba(0,0,0,.08)", zIndex:20 }}>
 
-          {/* Header */}
-          <div style={{ marginBottom: 16 }}>
-            <p style={{
-              fontSize: 11, fontWeight: 600, color: "#8a7d5e",
-              textTransform: "uppercase", letterSpacing: "1.5px", margin: "0 0 6px",
-            }}>Get Started</p>
-            <h2 style={{
-              fontFamily: "'Cormorant Garamond', Georgia, serif",
-              fontSize: 28, fontWeight: 700, color: "#1a1714",
-              letterSpacing: "-0.5px", margin: "0 0 6px", lineHeight: 1.15,
-            }}>
-              Create your<br />account
-            </h2>
-            <p style={{ fontSize: 13, color: "#9c9082", margin: 0, lineHeight: 1.6 }}>
-              Join thousands managing properties smarter.
-            </p>
-          </div>
+          <div style={{ position:"absolute", top:0, left:0, right:0, height:3, background:"linear-gradient(90deg,#1a1714,#8a7d5e,#c9b87a,#8a7d5e,#1a1714)" }} />
 
-          {/* Form */}
-          <div style={{ display: "flex", flexDirection: "column", gap: 9 }}>
-
-            {/* Company name */}
-            <div>
-              <label style={{
-                display: "block", fontSize: 11, fontWeight: 600,
-                color: "#6b6248", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 6,
-              }}>Company Name</label>
-              <input
-                className="reg-input"
-                placeholder="Acme Properties"
-
-                value={companyName}
-                onChange={e => setCompanyName(e.target.value)}
-              />
+          {/* ── Token invalid ── */}
+          {isInvited && inviteError && (
+            <div style={{ background:"#fff8f5", border:"1.5px solid #f5c6a0", borderRadius:12, padding:"20px 18px", textAlign:"center" }}>
+              <div style={{ fontSize:32, marginBottom:10 }}>🔗</div>
+              <p style={{ fontSize:15, fontWeight:700, color:"#7a3a1a", margin:"0 0 6px" }}>Link i pavlefshëm</p>
+              <p style={{ fontSize:13, color:"#9c7060", margin:"0 0 16px" }}>{inviteError}</p>
+              <Link to="/" style={{ fontSize:13, color:"#6b6248", fontWeight:600 }}>← Kthehu te login</Link>
             </div>
+          )}
 
-            {/* First + Last name row */}
-            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-              <div>
-                <label style={{
-                  display: "block", fontSize: 11, fontWeight: 600,
-                  color: "#6b6248", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 6,
-                }}>First Name</label>
-                <input
-                  className="reg-input"
-                  placeholder="John"
-                  value={firstName}
-                  onChange={e => setFirstName(e.target.value)}
-                />
+          {/* ── Token duke u verifikuar ── */}
+          {isInvited && inviteLoading && (
+            <div style={{ textAlign:"center", padding:"32px 0" }}>
+              <div style={{ width:24, height:24, border:"2.5px solid #e4ddd0", borderTop:"2.5px solid #8a7d5e", borderRadius:"50%", animation:"spin .7s linear infinite", margin:"0 auto 12px" }} />
+              <p style={{ fontSize:13, color:"#9c9082" }}>Duke verifikuar linkun...</p>
+            </div>
+          )}
+
+          {/* ── Forma kryesore ── */}
+          {(!isInvited || (isInvited && inviteData && !inviteError)) && !inviteLoading && (
+            <>
+              {/* Invitation banner */}
+              {isInvited && inviteData && (
+                <div style={{ background:"#f0fdf4", border:"1.5px solid #bbf7d0", borderRadius:12, padding:"12px 16px", marginBottom:18, display:"flex", alignItems:"center", gap:10 }}>
+                  <span style={{ fontSize:20 }}>🎉</span>
+                  <div>
+                    <p style={{ margin:0, fontSize:13, fontWeight:700, color:"#166534" }}>You've been invited!</p>
+                    <p style={{ margin:"2px 0 0", fontSize:12, color:"#15803d" }}>
+                      Joining <strong>{inviteData.tenant_name}</strong> as <strong>{roleLabel}</strong>
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              <div style={{ marginBottom:16 }}>
+                <p style={{ fontSize:11, fontWeight:600, color:"#8a7d5e", textTransform:"uppercase", letterSpacing:"1.5px", margin:"0 0 6px" }}>Get Started</p>
+                <h2 style={{ fontFamily:"'Cormorant Garamond',Georgia,serif", fontSize:28, fontWeight:700, color:"#1a1714", letterSpacing:"-0.5px", margin:"0 0 6px", lineHeight:1.15 }}>
+                  Create your<br />account
+                </h2>
+                <p style={{ fontSize:13, color:"#9c9082", margin:0, lineHeight:1.6 }}>
+                  {isInvited ? `Complete your profile to join ${inviteData?.tenant_name}.` : "Join thousands managing properties smarter."}
+                </p>
               </div>
-              <div>
-                <label style={{
-                  display: "block", fontSize: 11, fontWeight: 600,
-                  color: "#6b6248", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 6,
-                }}>Last Name</label>
-                <input
-                  className="reg-input"
-                  placeholder="Doe"
-                  value={lastName}
-                  onChange={e => setLastName(e.target.value)}
-                />
-              </div>
-            </div>
 
-            {/* Email */}
-            <div>
-              <label style={{
-                display: "block", fontSize: 11, fontWeight: 600,
-                color: "#6b6248", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 6,
-              }}>Email Address</label>
-              <input
-                className="reg-input"
-                type="email"
-                placeholder="name@example.com"
-                value={email}
-                onChange={e => setEmail(e.target.value)}
-              />
-            </div>
+              <div style={{ display:"flex", flexDirection:"column", gap:9 }}>
 
-            {/* Password */}
-            <div>
-              <label style={{
-                display: "block", fontSize: 11, fontWeight: 600,
-                color: "#6b6248", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 6,
-              }}>Password</label>
-              <div style={{ position: "relative" }}>
-                <input
-                  className="reg-input"
-                  type={showPw ? "text" : "password"}
-                  placeholder="Min. 8 characters"
-                  value={password}
-                  onChange={e => setPassword(e.target.value)}
-                  style={{ paddingRight: 46 }}
-                />
-                <button onClick={() => setShowPw(p => !p)} style={{
-                  position: "absolute", right: 14, top: "50%", transform: "translateY(-50%)",
-                  background: "none", border: "none", cursor: "pointer",
-                  fontSize: 15, color: "#9c9082", transition: "color 0.15s", padding: 0,
-                }}>{showPw ? "🙈" : "👁️"}</button>
-              </div>
-            </div>
+                {/* Company name — vetëm nëse jo invited */}
+                {!isInvited && (
+                  <div>
+                    <label style={{ display:"block", fontSize:11, fontWeight:600, color:"#6b6248", textTransform:"uppercase", letterSpacing:"0.8px", marginBottom:6 }}>Company Name</label>
+                    <input className="reg-input" placeholder="Acme Properties" value={companyName} onChange={e => setCompanyName(e.target.value)} />
+                  </div>
+                )}
 
-            {/* Role selector */}
-            <div>
-              <label style={{
-                display: "block", fontSize: 11, fontWeight: 600,
-                color: "#6b6248", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 8,
-              }}>Account Type</label>
-              <div style={{ display: "flex", gap: 8 }}>
-                {ROLES.map(r => (
-                  <button
-                    key={r.value}
-                    className={`role-card ${role === r.value ? "selected" : ""}`}
-                    onClick={() => setRole(r.value)}
-                    style={{ border: "none", textAlign: "left" }}
-                  >
-                    <span style={{ fontSize: 18, lineHeight: 1 }}>{r.icon}</span>
-                    <div>
-                      <div style={{
-                        fontSize: 12, fontWeight: 700,
-                        color: role === r.value ? "#e8dfc8" : "#1a1714",
-                        letterSpacing: "0.2px",
-                      }}>{r.label}</div>
-                      <div style={{
-                        fontSize: 10, lineHeight: 1.4,
-                        color: role === r.value ? "rgba(232,223,200,0.6)" : "#9c9082",
-                        marginTop: 2,
-                      }}>{r.desc}</div>
+                {/* First + Last name */}
+                <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:10 }}>
+                  <div>
+                    <label style={{ display:"block", fontSize:11, fontWeight:600, color:"#6b6248", textTransform:"uppercase", letterSpacing:"0.8px", marginBottom:6 }}>First Name</label>
+                    <input className="reg-input" placeholder="John" value={firstName} onChange={e => setFirstName(e.target.value)} />
+                  </div>
+                  <div>
+                    <label style={{ display:"block", fontSize:11, fontWeight:600, color:"#6b6248", textTransform:"uppercase", letterSpacing:"0.8px", marginBottom:6 }}>Last Name</label>
+                    <input className="reg-input" placeholder="Doe" value={lastName} onChange={e => setLastName(e.target.value)} />
+                  </div>
+                </div>
+
+                {/* Email */}
+                <div>
+                  <label style={{ display:"block", fontSize:11, fontWeight:600, color:"#6b6248", textTransform:"uppercase", letterSpacing:"0.8px", marginBottom:6 }}>Email Address</label>
+                  <input className="reg-input" type="email" placeholder="name@example.com" value={email} onChange={e => setEmail(e.target.value)} />
+                </div>
+
+                {/* Password */}
+                <div>
+                  <label style={{ display:"block", fontSize:11, fontWeight:600, color:"#6b6248", textTransform:"uppercase", letterSpacing:"0.8px", marginBottom:6 }}>Password</label>
+                  <div style={{ position:"relative" }}>
+                    <input className="reg-input" type={showPw?"text":"password"} placeholder="Min. 8 characters" value={password} onChange={e => setPassword(e.target.value)} style={{ paddingRight:46 }} />
+                    <button onClick={() => setShowPw(p => !p)} style={{ position:"absolute", right:14, top:"50%", transform:"translateY(-50%)", background:"none", border:"none", cursor:"pointer", fontSize:15, color:"#9c9082", padding:0 }}>
+                      {showPw ? "🙈" : "👁️"}
+                    </button>
+                  </div>
+                </div>
+
+                {/* Role selector — vetëm nëse jo invited */}
+                {!isInvited && (
+                  <div>
+                    <label style={{ display:"block", fontSize:11, fontWeight:600, color:"#6b6248", textTransform:"uppercase", letterSpacing:"0.8px", marginBottom:8 }}>Account Type</label>
+                    <div style={{ display:"flex", gap:8 }}>
+                      {ROLES.map(r => (
+                        <button key={r.value} className={`role-card ${role===r.value?"selected":""}`} onClick={() => setRole(r.value)} style={{ border:"none", textAlign:"left" }}>
+                          <span style={{ fontSize:18, lineHeight:1 }}>{r.icon}</span>
+                          <div>
+                            <div style={{ fontSize:12, fontWeight:700, color:role===r.value?"#e8dfc8":"#1a1714" }}>{r.label}</div>
+                            <div style={{ fontSize:10, lineHeight:1.4, color:role===r.value?"rgba(232,223,200,.6)":"#9c9082", marginTop:2 }}>{r.desc}</div>
+                          </div>
+                        </button>
+                      ))}
                     </div>
-                  </button>
-                ))}
+                  </div>
+                )}
+
+                {/* Role badge — kur është invited */}
+                {isInvited && inviteData && (
+                  <div style={{ display:"flex", alignItems:"center", gap:8, padding:"10px 14px", background:"#f5f0e8", borderRadius:10, border:"1px solid #e4ddd0" }}>
+                    <span style={{ fontSize:16 }}>{ROLES.find(r => r.value === role)?.icon}</span>
+                    <div>
+                      <p style={{ margin:0, fontSize:12, fontWeight:700, color:"#1a1714" }}>Account type: {roleLabel}</p>
+                      <p style={{ margin:0, fontSize:11, color:"#9c9082" }}>Set by your invitation link</p>
+                    </div>
+                  </div>
+                )}
+
+                {/* Error */}
+                {error && (
+                  <div style={{ background:"#fff8f5", border:"1px solid #f5c6a0", borderRadius:10, padding:"11px 15px", fontSize:13, color:"#7a3a1a", display:"flex", alignItems:"center", gap:8 }}>
+                    <span>⚠️</span> {error}
+                  </div>
+                )}
+
+                <button className="reg-btn" onClick={handleRegister} disabled={loading}>
+                  {loading ? (
+                    <>
+                      <div style={{ width:16, height:16, border:"2px solid rgba(255,255,255,.3)", borderTop:"2px solid #e8dfc8", borderRadius:"50%", animation:"spin .7s linear infinite" }} />
+                      Creating account...
+                    </>
+                  ) : "Create Account →"}
+                </button>
+
+                <div style={{ display:"flex", alignItems:"center", gap:12 }}>
+                  <div style={{ flex:1, height:1, background:"#e8e0d0" }} />
+                  <span style={{ fontSize:12, color:"#b0a88e" }}>or</span>
+                  <div style={{ flex:1, height:1, background:"#e8e0d0" }} />
+                </div>
+
+                <Link to="/" className="login-link-btn">
+                  Already have an account? <strong style={{ color:"#3d3828" }}>Sign in</strong>
+                </Link>
               </div>
-            </div>
 
-            {/* Error */}
-            {error && (
-              <div style={{
-                background: "#fff8f5", border: "1px solid #f5c6a0",
-                borderRadius: 10, padding: "11px 15px",
-                fontSize: 13, color: "#7a3a1a",
-                display: "flex", alignItems: "center", gap: 8,
-              }}>
-                <span>⚠️</span> {error}
+              <p style={{ fontSize:11.5, color:"#b0a88e", textAlign:"center", marginTop:18, lineHeight:1.7 }}>
+                By registering you agree to our{" "}
+                <span style={{ color:"#6b6248", fontWeight:600, cursor:"pointer" }}>Terms of Service</span>
+                {" "}and{" "}
+                <span style={{ color:"#6b6248", fontWeight:600, cursor:"pointer" }}>Privacy Policy</span>.
+              </p>
+
+              <div style={{ display:"flex", alignItems:"center", justifyContent:"center", gap:7, opacity:.3, marginTop:12 }}>
+                <span style={{ fontSize:13 }}>🏡</span>
+                <span style={{ fontSize:11.5, fontWeight:600, color:"#1a1714", letterSpacing:"0.3px" }}>PropManager</span>
               </div>
-            )}
-
-            {/* Submit */}
-            <button className="reg-btn" onClick={handleRegister} disabled={loading}>
-              {loading ? (
-                <>
-                  <div style={{
-                    width: 16, height: 16,
-                    border: "2px solid rgba(255,255,255,0.3)",
-                    borderTop: "2px solid #e8dfc8",
-                    borderRadius: "50%",
-                    animation: "spin 0.7s linear infinite",
-                  }} />
-                  Creating account...
-                </>
-              ) : "Create Account →"}
-            </button>
-
-            {/* Divider */}
-            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-              <div style={{ flex: 1, height: 1, background: "#e8e0d0" }} />
-              <span style={{ fontSize: 12, color: "#b0a88e" }}>or</span>
-              <div style={{ flex: 1, height: 1, background: "#e8e0d0" }} />
-            </div>
-
-            {/* Login link */}
-            <Link to="/" className="login-link-btn">
-              Already have an account? <strong style={{ color: "#3d3828" }}>Sign in</strong>
-            </Link>
-          </div>
-
-          {/* Footer */}
-          <p style={{
-            fontSize: 11.5, color: "#b0a88e", textAlign: "center",
-            marginTop: 18, lineHeight: 1.7,
-          }}>
-            By registering you agree to our{" "}
-            <span style={{ color: "#6b6248", fontWeight: 600, cursor: "pointer" }}>Terms of Service</span>
-            {" "}and{" "}
-            <span style={{ color: "#6b6248", fontWeight: 600, cursor: "pointer" }}>Privacy Policy</span>.
-          </p>
-
-          {/* Bottom logo */}
-          <div style={{
-            display: "flex", alignItems: "center", justifyContent: "center", gap: 7,
-            opacity: 0.3, marginTop: 12,
-          }}>
-            <span style={{ fontSize: 13 }}>🏡</span>
-            <span style={{ fontSize: 11.5, fontWeight: 600, color: "#1a1714", letterSpacing: "0.3px" }}>PropManager</span>
-          </div>
+            </>
+          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
Add invite generation and invitation flow for agents and clients. Admin toolbars (AgentsToolbar, ClientsToolbar) now call POST /api/invites to generate single-use links, show an InviteModal with a copy-to-clipboard link, and surface generation errors/states. AuthProvider stores tenantSlug (from schema_name) in user_info, accepts inviteToken in the register payload, and contains minor formatting/refactor cleanups. Admin pages pass tenantSlug to toolbars. Register page now supports ?token= invite links: it validates the token via GET /api/invites/:token, pre-fills tenant info, adjusts validation for invited users, includes inviteToken on register, and marks invites used with PATCH /api/invites/:token/use after successful registration. Also remove the register link/divider from the Login page and tidy styles/formatting across components.

Closes #175 