### PR TITLE
[CLIENT] Refactor: split client pages into component folders

### DIFF
--- a/src/components/client/applications/ApplicationCard.jsx
+++ b/src/components/client/applications/ApplicationCard.jsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { STATUS_CONFIG, fmtDate, fmtMon, CalendarIcon, EuroIcon, HomeIcon, CloseIcon } from "./applicationsConstants";
+import { ConfirmCancelModal, ListingDetail } from "./ApplicationModals";
+ 
+export default function ApplicationCard({ app, onCancel }) {
+  const [cancelling,  setCancelling]  = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+ 
+  const s = STATUS_CONFIG[app.status] || STATUS_CONFIG.CANCELLED;
+ 
+  const handleConfirmCancel = async () => {
+    setCancelling(true);
+    await onCancel(app.id);
+    setCancelling(false);
+    setShowConfirm(false);
+  };
+ 
+  return (
+    <>
+      <div
+        style={{ background: "#fff", borderRadius: "14px", overflow: "hidden", boxShadow: "0 2px 12px rgba(90,95,58,0.10)", border: "1px solid #ede9df", transition: "transform 0.18s, box-shadow 0.18s" }}
+        onMouseEnter={e => { e.currentTarget.style.transform = "translateY(-3px)"; e.currentTarget.style.boxShadow = "0 8px 28px rgba(90,95,58,0.18)"; }}
+        onMouseLeave={e => { e.currentTarget.style.transform = "translateY(0)"; e.currentTarget.style.boxShadow = "0 2px 12px rgba(90,95,58,0.10)"; }}
+      >
+        <div style={{ height: "4px", background: s.strip }} />
+ 
+        <div style={{ padding: "18px 22px" }}>
+          {/* Top row */}
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "12px", marginBottom: "14px" }}>
+            <div>
+              <div style={{ fontSize: "11px", fontWeight: 700, color: "#a0997e", textTransform: "uppercase", letterSpacing: "0.6px", marginBottom: "4px" }}>
+                Application #{app.id}
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: "5px", color: "#8a8469", fontSize: "12.5px" }}>
+                <CalendarIcon />
+                <span>Submitted on {fmtDate(app.created_at)}</span>
+              </div>
+            </div>
+            <span style={{ background: s.bg, color: s.color, border: `1px solid ${s.border}`, padding: "3px 12px", borderRadius: "20px", fontSize: "12px", fontWeight: 700, display: "flex", alignItems: "center", gap: "4px", flexShrink: 0 }}>
+              {s.icon} {s.label}
+            </span>
+          </div>
+ 
+          {/* Listing section */}
+          <div style={{ marginBottom: "12px" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: "5px", fontSize: "11.5px", fontWeight: 700, color: "#6b6651", textTransform: "uppercase", letterSpacing: "0.5px", marginBottom: "2px" }}>
+              <HomeIcon /> Listing
+            </div>
+            <ListingDetail listingId={app.listing_id} />
+          </div>
+ 
+          {/* Income / move-in */}
+          {(app.income != null || app.move_in_date) && (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 20px", padding: "10px 14px", background: "#f5f2eb", borderRadius: "8px", border: "1px solid #e5e0d4", marginBottom: "12px" }}>
+              {app.income != null && (
+                <span style={{ fontSize: "12.5px", color: "#4a4a36", display: "flex", alignItems: "center", gap: 4 }}>
+                  <EuroIcon /> Income: <strong>{fmtMon(app.income)}/month</strong>
+                </span>
+              )}
+              {app.move_in_date && (
+                <span style={{ fontSize: "12.5px", color: "#4a4a36", display: "flex", alignItems: "center", gap: 4 }}>
+                  <CalendarIcon /> Move-in Date: <strong>{fmtDate(app.move_in_date)}</strong>
+                </span>
+              )}
+            </div>
+          )}
+ 
+          {/* Message */}
+          {app.message && (
+            <div style={{ padding: "10px 14px", background: "#f5f2eb", borderLeft: "3px solid #a3a380", borderRadius: "0 8px 8px 0", marginBottom: "12px" }}>
+              <p style={{ margin: 0, fontSize: "13px", color: "#4a4a36", fontStyle: "italic", lineHeight: 1.6 }}>"{app.message}"</p>
+            </div>
+          )}
+ 
+          {/* Status banners */}
+          {app.status === "APPROVED" && (
+            <div style={{ background: "#edf5f0", border: "1px solid #a3c9b0", borderRadius: "10px", padding: "12px 14px", fontSize: "13px", color: "#2a6049", display: "flex", alignItems: "center", gap: 8, marginBottom: "4px" }}>
+              🎉 <span>Your application has been approved! The agent will contact you soon.</span>
+            </div>
+          )}
+          {app.status === "CANCELLED" && (
+            <div style={{ background: "#f5f2eb", border: "1px solid #d9d4c7", borderRadius: "10px", padding: "12px 14px", fontSize: "13px", color: "#8a8469", display: "flex", alignItems: "center", gap: 8, marginBottom: "4px" }}>
+              🚫 <span>This application has been cancelled.</span>
+            </div>
+          )}
+          {app.status === "REJECTED" && (
+            <div style={{ background: "#fff5ee", border: "1px solid #f5c6a0", borderRadius: "10px", padding: "12px 14px", fontSize: "13px", color: "#8b4513", display: "flex", alignItems: "center", gap: 8, marginBottom: "4px" }}>
+              ❌ <span>Your application has been rejected.</span>
+            </div>
+          )}
+ 
+          {/* Cancel button */}
+          {app.status === "PENDING" && (
+            <div style={{ marginTop: "14px" }}>
+              <button
+                onClick={() => setShowConfirm(true)}
+                style={{ padding: "8px 18px", borderRadius: "8px", border: "1.5px solid #d9c4b0", background: "#fff", color: "#8b4513", fontSize: "13px", fontWeight: 600, cursor: "pointer", fontFamily: "inherit", transition: "all 0.15s", display: "flex", alignItems: "center", gap: 6 }}
+                onMouseEnter={e => { e.currentTarget.style.background = "#fff5ee"; }}
+                onMouseLeave={e => { e.currentTarget.style.background = "#fff"; }}
+              >
+                <CloseIcon /> Cancel Application
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+ 
+      {showConfirm && (
+        <ConfirmCancelModal loading={cancelling} onConfirm={handleConfirmCancel} onClose={() => setShowConfirm(false)} />
+      )}
+    </>
+  );
+}
+ 

--- a/src/components/client/applications/ApplicationModals.jsx
+++ b/src/components/client/applications/ApplicationModals.jsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from "react";
+import api from "../../../api/axios";
+import { CalendarIcon, EuroIcon, ClockIcon } from "./applicationsConstants";
+ 
+// ─── Confirm Cancel Modal ─────────────────────────────────────────────────────
+export function ConfirmCancelModal({ onConfirm, onClose, loading }) {
+  useEffect(() => {
+    const h = e => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [onClose]);
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+ 
+  return (
+    <div
+      onClick={e => e.target === e.currentTarget && onClose()}
+      style={{ position: "fixed", inset: 0, background: "rgba(20,20,10,0.72)", backdropFilter: "blur(4px)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: "20px", animation: "fadeInOverlay 0.2s ease" }}
+    >
+      <div style={{ background: "#faf8f3", borderRadius: "18px", width: "100%", maxWidth: "400px", boxShadow: "0 24px 64px rgba(0,0,0,0.35)", animation: "slideUpModal 0.25s ease", padding: "32px 28px 26px" }}>
+        <div style={{ textAlign: "center", marginBottom: 24 }}>
+          <div style={{ fontSize: "40px", marginBottom: "12px" }}>⚠️</div>
+          <p style={{ fontWeight: 800, fontSize: "17px", margin: "0 0 8px", color: "#2c2c1e" }}>Cancel application?</p>
+          <p style={{ fontSize: "13.5px", color: "#8a8469", margin: 0, lineHeight: 1.5 }}>This action cannot be undone.</p>
+        </div>
+        <div style={{ display: "flex", gap: 10 }}>
+          <button onClick={onClose}
+            style={{ flex: 1, padding: "11px", borderRadius: "10px", border: "1.5px solid #d9d4c7", background: "#fff", color: "#5a5f3a", fontWeight: 600, fontSize: "14px", cursor: "pointer", fontFamily: "inherit" }}>
+            No, keep it
+          </button>
+          <button onClick={onConfirm} disabled={loading}
+            style={{ flex: 1, padding: "11px", borderRadius: "10px", border: "none", background: loading ? "#c5a08a" : "#8b4513", color: "#fff", fontWeight: 700, fontSize: "14px", cursor: loading ? "not-allowed" : "pointer", fontFamily: "inherit" }}>
+            {loading ? "Canceling..." : "Yes, cancel"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+ 
+// ─── Listing Detail ───────────────────────────────────────────────────────────
+export function ListingDetail({ listingId }) {
+  const [listing, setListing] = useState(null);
+  const [loading, setLoading] = useState(true);
+ 
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await api.get(`/api/rentals/listings/${listingId}`);
+        if (!cancelled) setListing(res.data);
+      } catch {}
+      finally { if (!cancelled) setLoading(false); }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [listingId]);
+ 
+  if (loading) return (
+    <div style={{ display: "flex", gap: 6, alignItems: "center", fontSize: "12px", color: "#a0997e", marginTop: 6 }}>
+      <div style={{ width: 12, height: 12, border: "2px solid #e5e0d4", borderTop: "2px solid #5a5f3a", borderRadius: "50%", animation: "spin .7s linear infinite" }} />
+      Loading details...
+    </div>
+  );
+ 
+  if (!listing) return <div style={{ marginTop: 6, fontSize: "12px", color: "#a0997e" }}>Listing #{listingId}</div>;
+ 
+  const fmtMoney = v => v != null ? `€${Number(v).toLocaleString("de-DE")}` : null;
+  const fmtDate  = d => d ? new Date(d).toLocaleDateString("sq-AL") : null;
+ 
+  return (
+    <div style={{ marginTop: 10, background: "#f5f2eb", border: "1px solid #e5e0d4", borderRadius: "10px", padding: "12px 16px" }}>
+      <p style={{ fontWeight: 700, fontSize: "13.5px", margin: "0 0 6px", color: "#2c2c1e" }}>
+        {listing.title || `Listing #${listing.id}`}
+      </p>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 18px", fontSize: "12.5px", color: "#6b6651" }}>
+        {listing.price != null && (
+          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <EuroIcon />{fmtMoney(listing.price)} / {(listing.price_period || "monthly").toLowerCase()}
+          </span>
+        )}
+        {listing.deposit != null && (
+          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <EuroIcon />Deposit: {fmtMoney(listing.deposit)}
+          </span>
+        )}
+        {listing.min_lease_months && (
+          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <ClockIcon />Min. {listing.min_lease_months} months
+          </span>
+        )}
+        {listing.available_from && (
+          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <CalendarIcon />From {fmtDate(listing.available_from)}
+          </span>
+        )}
+        {listing.available_until && (
+          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <CalendarIcon />Until {fmtDate(listing.available_until)}
+          </span>
+        )}
+      </div>
+      {listing.description && (
+        <p style={{ margin: "8px 0 0", fontSize: "12.5px", color: "#4a4a36", lineHeight: 1.6 }}>
+          {listing.description}
+        </p>
+      )}
+    </div>
+  );
+}
+ 

--- a/src/components/client/applications/ApplicationsUI.jsx
+++ b/src/components/client/applications/ApplicationsUI.jsx
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import { S, ChevronLeftIcon, ChevronRightIcon } from "./applicationsConstants";
+ 
+export function Toast({ msg, type = "success", onDone }) {
+  useEffect(() => {
+    const t = setTimeout(onDone, 3200);
+    return () => clearTimeout(t);
+  }, [onDone]);
+  return (
+    <div style={{
+      position: "fixed", bottom: 28, right: 28, zIndex: 9999,
+      background: type === "error" ? "#fee2e2" : "#ecfdf5",
+      color: type === "error" ? "#b91c1c" : "#047857",
+      padding: "12px 20px", borderRadius: 10, fontSize: 13.5, fontWeight: 500,
+      boxShadow: "0 4px 18px rgba(0,0,0,0.12)", maxWidth: 340,
+    }}>{msg}</div>
+  );
+}
+ 
+export function Skeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} style={{ background: "#f0ece3", borderRadius: "14px", height: "160px", animation: "pulse 1.4s ease-in-out infinite" }} />
+      ))}
+    </div>
+  );
+}
+ 
+export function Pagination({ page, totalPages, onLoadApps, statusFilter }) {
+  if (totalPages <= 1) return null;
+  const pages   = Array.from({ length: totalPages }, (_, i) => i);
+  const visible = pages.filter(p => p === 0 || p === totalPages - 1 || Math.abs(p - page) <= 1);
+  return (
+    <div style={{ display: "flex", justifyContent: "center", gap: "6px", marginTop: "36px", flexWrap: "wrap" }}>
+      <button disabled={page === 0} onClick={() => onLoadApps(page - 1, statusFilter)}
+        style={S.pageBtn(false, page === 0)}><ChevronLeftIcon /></button>
+      {visible.map((p, i) => {
+        const gap = visible[i - 1] != null && p - visible[i - 1] > 1;
+        return (
+          <span key={p} style={{ display: "flex", gap: "6px" }}>
+            {gap && <span style={{ padding: "6px 4px", color: "#8a8469" }}>…</span>}
+            <button onClick={() => onLoadApps(p, statusFilter)} style={S.pageBtn(p === page, false)}>{p + 1}</button>
+          </span>
+        );
+      })}
+      <button disabled={page === totalPages - 1} onClick={() => onLoadApps(page + 1, statusFilter)}
+        style={S.pageBtn(false, page === totalPages - 1)}><ChevronRightIcon /></button>
+    </div>
+  );
+}
+ 

--- a/src/components/client/applications/applicationsConstants.jsx
+++ b/src/components/client/applications/applicationsConstants.jsx
@@ -1,0 +1,75 @@
+export const STATUS_CONFIG = {
+  PENDING:   { bg: "#fffbeb", color: "#c9a84c", border: "#f0d878", label: "Në pritje", icon: "⏳", strip: "#c9a84c" },
+  APPROVED:  { bg: "#edf5f0", color: "#2a6049", border: "#a3c9b0", label: "Aprovuar",  icon: "✅", strip: "#2a6049" },
+  REJECTED:  { bg: "#fef2f2", color: "#8b4513", border: "#f5c6a0", label: "Refuzuar",  icon: "❌", strip: "#8b4513" },
+  CANCELLED: { bg: "#f5f2eb", color: "#8a8469", border: "#d9d4c7", label: "Anuluar",   icon: "🚫", strip: "#a0997e" },
+};
+ 
+export const STATUS_FILTERS = [
+  { value: "",          label: "Të gjitha" },
+  { value: "PENDING",   label: "Në pritje"  },
+  { value: "APPROVED",  label: "Aprovuar"   },
+  { value: "REJECTED",  label: "Refuzuar"   },
+  { value: "CANCELLED", label: "Anuluar"    },
+];
+ 
+export const fmtDate = d => d ? new Date(d).toLocaleDateString("sq-AL", { day: "2-digit", month: "long", year: "numeric" }) : "—";
+export const fmtMon  = v => v != null ? `€${Number(v).toLocaleString("de-DE")}` : null;
+ 
+export const S = {
+  applyBtn: {
+    width: "100%", padding: "11px", background: "#5a5f3a", color: "#fff",
+    border: "none", borderRadius: "10px", fontSize: "14px", fontWeight: 700,
+    cursor: "pointer", fontFamily: "'Georgia', serif",
+  },
+  pageBtn: (active, disabled) => ({
+    padding: "7px 13px", borderRadius: "8px", border: "1.5px solid",
+    borderColor: active ? "#5a5f3a" : "#d9d4c7",
+    background:  active ? "#5a5f3a" : "#fff",
+    color: active ? "#fff" : disabled ? "#c5bfaf" : "#5a5f3a",
+    cursor: disabled ? "not-allowed" : "pointer",
+    fontSize: "13px", fontWeight: active ? 700 : 400,
+    fontFamily: "inherit", transition: "all 0.15s",
+    display: "flex", alignItems: "center", justifyContent: "center",
+    minWidth: "36px", minHeight: "36px",
+  }),
+};
+ 
+// ─── Icons ────────────────────────────────────────────────────────────────────
+export const CalendarIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect width="18" height="18" x="3" y="4" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/>
+    <line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
+  </svg>
+);
+export const EuroIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M4 10h12"/><path d="M4 14h9"/><path d="M19 6a7 7 0 1 0 0 12"/>
+  </svg>
+);
+export const HomeIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>
+  </svg>
+);
+export const ClockIcon = () => (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+  </svg>
+);
+export const CloseIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+  </svg>
+);
+export const ChevronLeftIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="m15 18-6-6 6-6"/>
+  </svg>
+);
+export const ChevronRightIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="m9 18 6-6-6-6"/>
+  </svg>
+);
+ 

--- a/src/components/client/leads/CreateLeadModal.jsx
+++ b/src/components/client/leads/CreateLeadModal.jsx
@@ -1,0 +1,195 @@
+import { useState } from "react";
+import api from "../../../api/axios";
+import { ModalWrap, MH, Field } from "./LeadsUI";
+import PropertyFields from "./PropertyFields";
+import { TYPE_ICON, HomeIcon } from "./LeadsIcons";
+import {
+  LEAD_TYPES, LEAD_SOURCES, TYPE_LABEL, SOURCE_LABEL,
+  INP_S, SEL_S,
+} from "./leadsConstants";
+ 
+const EMPTY_PD = {
+  title: "", type: "APARTMENT", area_sqm: "", bedrooms: "",
+  bathrooms: "", price: "", price_per_sqm: "", currency: "EUR",
+  city: "", street: "", year_built: "", floor: "",
+  total_floors: "", description: "", price_period: "MONTHLY",
+};
+ 
+export default function CreateLeadModal({ onClose, onSuccess, notify }) {
+  const [form, setForm] = useState({
+    type:           "SELL",
+    message:        "",
+    preferred_date: "",
+    source:         "WEBSITE",
+    property_data:  { ...EMPTY_PD },
+  });
+  const [saving, setSaving] = useState(false);
+  const set = (k, v) => setForm(p => ({ ...p, [k]: v }));
+ 
+  const handleTypeChange = t => {
+    setForm(p => ({
+      ...p,
+      type:          t,
+      property_data: t === "VALUATION" ? null : (p.property_data || { ...EMPTY_PD }),
+    }));
+  };
+ 
+  const buildMessage = () => {
+    const parts = [];
+    if (form.message?.trim()) parts.push(form.message.trim());
+    const pd = form.property_data;
+    if (pd && form.type !== "VALUATION") {
+      parts.push("\n--- Property Details ---");
+      if (pd.title)         parts.push(`Title: ${pd.title}`);
+      if (pd.type)          parts.push(`Type: ${pd.type}`);
+      if (pd.city)          parts.push(`City: ${pd.city}`);
+      if (pd.street)        parts.push(`Address: ${pd.street}`);
+      if (pd.area_sqm)      parts.push(`Area: ${pd.area_sqm} m²`);
+      if (pd.bedrooms)      parts.push(`Bedrooms: ${pd.bedrooms}`);
+      if (pd.bathrooms)     parts.push(`Bathrooms: ${pd.bathrooms}`);
+      if (pd.floor)         parts.push(`Floor: ${pd.floor}`);
+      if (pd.total_floors)  parts.push(`Total floors: ${pd.total_floors}`);
+      if (pd.year_built)    parts.push(`Year built: ${pd.year_built}`);
+      if (pd.price)         parts.push(`Price: ${pd.price} ${pd.currency}`);
+      if (pd.price_per_sqm) parts.push(`Price per m²: ${pd.price_per_sqm} ${pd.currency}`);
+      if (pd.price_period && form.type === "RENT") parts.push(`Period: ${pd.price_period}`);
+      if (pd.description)   parts.push(`Notes: ${pd.description}`);
+      parts.push(`\n__PROPERTY_DATA__:${JSON.stringify(pd)}`);
+    }
+    return parts.join("\n").trim() || null;
+  };
+ 
+  const handleSubmit = async () => {
+    if (form.type !== "VALUATION") {
+      const pd = form.property_data;
+      if (!pd?.title?.trim()) { notify("Property title is required", "error"); return; }
+      if (!pd?.city?.trim())  { notify("City is required", "error"); return; }
+      if (!pd?.price)         { notify("Price is required", "error"); return; }
+    } else {
+      if (!form.message?.trim()) { notify("Please describe the property you want valued", "error"); return; }
+    }
+    setSaving(true);
+    try {
+      await api.post("/api/leads", {
+        type:           form.type,
+        property_id:    null,
+        message:        buildMessage(),
+        budget:         null,
+        preferred_date: form.preferred_date || null,
+        source:         form.source,
+      });
+      onSuccess();
+    } catch (err) {
+      notify(err.response?.data?.message || "Error submitting request", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+ 
+  const DATE_LABEL = {
+    SELL:      "Preferred listing date",
+    RENT:      "Date property is available from",
+    VALUATION: "Preferred valuation date",
+  };
+ 
+  const INFO = {
+    SELL:      { text: "Have a property to sell? Fill in the details — your agent will register and list it.",         accent: "#c9b87a", bg: "rgba(201,184,122,0.07)", border: "rgba(201,184,122,0.18)" },
+    RENT:      { text: "Have a property to rent out? Provide the details — your agent will manage applications.",      accent: "#7eb8a4", bg: "rgba(126,184,164,0.07)", border: "rgba(126,184,164,0.18)" },
+    VALUATION: { text: "Want a professional property valuation? Describe the property in your message.",               accent: "#a4b07e", bg: "rgba(164,176,126,0.07)", border: "rgba(164,176,126,0.18)" },
+  };
+  const info = INFO[form.type] || INFO.SELL;
+ 
+  return (
+    <ModalWrap onClose={onClose} maxW={form.type !== "VALUATION" ? 700 : 520}>
+      <MH title="New Request" sub="Tell us what you need" onClose={onClose} />
+      <div style={{ padding: "22px 26px" }}>
+ 
+        <Field label="Request type" required>
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            {LEAD_TYPES.map(t => (
+              <button key={t} onClick={() => handleTypeChange(t)} style={{
+                display: "flex", alignItems: "center", gap: 7,
+                padding: "10px 18px", borderRadius: 10,
+                border: `1.5px solid ${form.type === t ? "#8a7d5e" : "#e4ddd0"}`,
+                background: form.type === t ? "#1a1714" : "transparent",
+                color: form.type === t ? "#f5f0e8" : "#6b6248",
+                cursor: "pointer", fontSize: 13,
+                fontWeight: form.type === t ? 600 : 400,
+                fontFamily: "'DM Sans',sans-serif", transition: "all 0.15s",
+              }}>
+                <span style={{ opacity: form.type === t ? 1 : 0.5 }}>{TYPE_ICON[t]}</span>
+                {TYPE_LABEL[t]}
+              </button>
+            ))}
+          </div>
+        </Field>
+ 
+        <div style={{
+          background: info.bg, border: `1.5px solid ${info.border}`,
+          borderRadius: 10, padding: "10px 14px", marginBottom: 16,
+          fontSize: 13, color: info.accent, display: "flex", alignItems: "flex-start", gap: 8,
+        }}>
+          <span style={{ opacity: 0.7, marginTop: 1, flexShrink: 0 }}><HomeIcon /></span>
+          {info.text}
+        </div>
+ 
+        {form.type !== "VALUATION" && (
+          <PropertyFields form={form} setForm={setForm} />
+        )}
+ 
+        <Field label={DATE_LABEL[form.type] || "Preferred date"}>
+          <input className="cl-in" style={INP_S} type="date"
+            value={form.preferred_date}
+            onChange={e => set("preferred_date", e.target.value)}
+            min={new Date().toISOString().split("T")[0]} />
+        </Field>
+ 
+        <Field label="How did you find us?">
+          <select className="cl-in" style={SEL_S}
+            value={form.source}
+            onChange={e => set("source", e.target.value)}>
+            {LEAD_SOURCES.map(s => (
+              <option key={s} value={s}>{SOURCE_LABEL[s]}</option>
+            ))}
+          </select>
+        </Field>
+ 
+        <Field
+          label={form.type === "VALUATION" ? "Describe the property" : "Additional notes"}
+          required={form.type === "VALUATION"}>
+          <textarea className="cl-in"
+            value={form.message}
+            onChange={e => set("message", e.target.value)}
+            rows={3}
+            placeholder={form.type === "VALUATION" ? "Describe the property you want valued..." : "Any other relevant details..."}
+            style={{ ...INP_S, resize: "vertical" }} />
+        </Field>
+ 
+        <div style={{
+          display: "flex", gap: 9, justifyContent: "flex-end",
+          borderTop: "1px solid #e8e2d6", paddingTop: 18, marginTop: 4,
+        }}>
+          <button onClick={onClose} className="cl-btn" style={{
+            padding: "10px 18px", borderRadius: 10,
+            border: "1.5px solid #e4ddd0", background: "transparent",
+            color: "#6b6248", fontWeight: 500, fontSize: 13,
+            cursor: "pointer", fontFamily: "inherit",
+          }}>Cancel</button>
+          <button onClick={handleSubmit} disabled={saving} className="cl-btn" style={{
+            padding: "10px 24px", borderRadius: 10, border: "none",
+            background: saving ? "#b0a890" : "linear-gradient(135deg,#c9b87a 0%,#b0983e 100%)",
+            color: "#1a1714", fontSize: 13, fontWeight: 700,
+            cursor: saving ? "not-allowed" : "pointer",
+            fontFamily: "inherit", display: "flex", alignItems: "center", gap: 7,
+          }}>
+            {saving
+              ? <><div style={{ width: 14, height: 14, border: "2px solid rgba(26,23,20,0.25)", borderTop: "2px solid #1a1714", borderRadius: "50%", animation: "cl-spin 0.7s linear infinite" }}/> Submitting…</>
+              : <><span style={{ fontSize: 13 }}>✓</span> Submit Request</>
+            }
+          </button>
+        </div>
+      </div>
+    </ModalWrap>
+  );
+}
+ 

--- a/src/components/client/leads/LeadCard.jsx
+++ b/src/components/client/leads/LeadCard.jsx
@@ -1,0 +1,143 @@
+import { TYPE_ICON, TagIcon, PinIcon, AreaIcon, BedIcon, CalendarIcon, UserIcon, ClockIcon, ArrowRightIcon } from "./LeadsIcons";
+import { STATUS, TYPE_LABEL, parsePD, fmtDate } from "./leadsConstants";
+ 
+export default function LeadCard({ lead, onClick, idx }) {
+  const pd = parsePD(lead.message);
+  const s  = STATUS[lead.status] || STATUS.NEW;
+ 
+  return (
+    <div className="cl-card" onClick={onClick}
+      style={{
+        background: "#fff", borderRadius: 14, overflow: "hidden",
+        boxShadow: "0 2px 14px rgba(20,16,10,0.08)",
+        border: "1.5px solid #ece6da", cursor: "pointer", display: "flex",
+        animation: `cl-card-in 0.38s ease ${Math.min(idx * 0.06, 0.4)}s both`,
+      }}>
+ 
+      {/* Left accent strip */}
+      <div style={{ width: 4, background: `linear-gradient(to bottom,${s.strip},${s.strip}66)`, flexShrink: 0 }}/>
+ 
+      {/* Icon column */}
+      <div style={{
+        width: 60, flexShrink: 0,
+        display: "flex", flexDirection: "column", alignItems: "center",
+        justifyContent: "center", gap: 7, padding: "14px 8px",
+        background: `${s.strip}07`, borderRight: "1.5px solid #f0ece3",
+      }}>
+        <div style={{
+          color: s.strip, width: 28, height: 28, borderRadius: 8,
+          background: `${s.strip}12`, border: `1.5px solid ${s.strip}28`,
+          display: "flex", alignItems: "center", justifyContent: "center",
+        }}>
+          {TYPE_ICON[lead.type] || <TagIcon />}
+        </div>
+        <span style={{
+          fontSize: 8.5, fontWeight: 700, color: s.color,
+          textTransform: "uppercase", letterSpacing: "0.5px",
+          textAlign: "center", lineHeight: 1.3,
+          background: `${s.strip}12`, padding: "2px 6px",
+          borderRadius: 5, border: `1px solid ${s.strip}25`,
+        }}>
+          {s.label}
+        </span>
+      </div>
+ 
+      {/* Main content */}
+      <div style={{
+        flex: 1, padding: "13px 18px",
+        display: "flex", flexDirection: "column", justifyContent: "space-between", minWidth: 0,
+      }}>
+        <div>
+          <div style={{
+            display: "flex", justifyContent: "space-between",
+            alignItems: "flex-start", gap: 12, marginBottom: 5,
+          }}>
+            <div style={{ minWidth: 0 }}>
+              <h3 style={{
+                margin: "0 0 3px", fontSize: 15.5, fontWeight: 700,
+                color: "#1a1714", fontFamily: "'Cormorant Garamond',Georgia,serif",
+                letterSpacing: "-0.1px", lineHeight: 1.2,
+                overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+              }}>
+                {TYPE_LABEL[lead.type] || lead.type}
+                {pd?.title && (
+                  <span style={{ fontWeight: 400, color: "#9a8c6e", fontSize: 13.5 }}>
+                    {" "}— {pd.title}
+                  </span>
+                )}
+              </h3>
+              <p style={{
+                fontSize: 11.5, color: "#b0a890", margin: 0,
+                display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap",
+              }}>
+                <span>#{lead.id}</span>
+                <span style={{ display: "flex", alignItems: "center", gap: 3 }}>
+                  <ClockIcon />{fmtDate(lead.created_at)}
+                </span>
+                {pd?.city && (
+                  <span style={{ display: "flex", alignItems: "center", gap: 3 }}>
+                    <PinIcon />{pd.city}
+                  </span>
+                )}
+              </p>
+            </div>
+ 
+            {pd?.price && (
+              <div style={{ flexShrink: 0, textAlign: "right" }}>
+                <div style={{
+                  fontSize: 17, fontWeight: 700, color: "#1a1714",
+                  fontFamily: "'Cormorant Garamond',Georgia,serif", letterSpacing: "-0.3px",
+                }}>
+                  €{Number(pd.price).toLocaleString("de-DE")}
+                  {pd.price_period && lead.type === "RENT" && (
+                    <span style={{ fontSize: 11, fontWeight: 400, color: "#9a8c6e" }}>
+                      /{pd.price_period}
+                    </span>
+                  )}
+                </div>
+                {pd.price_per_sqm && (
+                  <div style={{ fontSize: 11, color: "#9a8c6e" }}>
+                    €{Number(pd.price_per_sqm).toLocaleString("de-DE")}/m²
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+ 
+        {/* Footer */}
+        <div style={{
+          display: "flex", gap: 14, paddingTop: 9,
+          borderTop: "1px solid #f0ece3", flexWrap: "wrap", alignItems: "center",
+        }}>
+          {pd?.area_sqm && (
+            <span style={{ fontSize: 12, color: "#9a8c6e", display: "flex", alignItems: "center", gap: 4 }}>
+              <AreaIcon />{pd.area_sqm} m²
+            </span>
+          )}
+          {pd?.bedrooms && (
+            <span style={{ fontSize: 12, color: "#9a8c6e", display: "flex", alignItems: "center", gap: 4 }}>
+              <BedIcon />{pd.bedrooms} beds
+            </span>
+          )}
+          {lead.preferred_date && (
+            <span style={{ fontSize: 12, color: "#9a8c6e", display: "flex", alignItems: "center", gap: 4 }}>
+              <CalendarIcon />{fmtDate(lead.preferred_date)}
+            </span>
+          )}
+          <span style={{ fontSize: 12, color: "#9a8c6e", display: "flex", alignItems: "center", gap: 4 }}>
+            <UserIcon />
+            {lead.agent_name || (lead.assigned_agent_id ? `Agent #${lead.assigned_agent_id}` : "Not assigned yet")}
+          </span>
+          <span style={{
+            marginLeft: "auto", fontSize: 11.5, color: "#c9b87a",
+            fontWeight: 600, display: "flex", alignItems: "center", gap: 4,
+          }}>
+            View details <ArrowRightIcon />
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+ 

--- a/src/components/client/leads/LeadDetailModal.jsx
+++ b/src/components/client/leads/LeadDetailModal.jsx
@@ -1,0 +1,155 @@
+import { ModalWrap, MH } from "./LeadsUI";
+import { TYPE_ICON, TagIcon, HomeIcon, PinIcon, AreaIcon, BedIcon, CalendarIcon } from "./LeadsIcons";
+import { STATUS, TYPE_LABEL, SOURCE_LABEL, parsePD, cleanMsg, fmtDate, fmtDateTime } from "./leadsConstants";
+ 
+export default function LeadDetailModal({ lead, onClose }) {
+  const pd = parsePD(lead.message);
+  const s  = STATUS[lead.status] || STATUS.NEW;
+ 
+  return (
+    <ModalWrap onClose={onClose} maxW={580}>
+      <MH
+        title={TYPE_LABEL[lead.type] || lead.type}
+        sub={`Request #${lead.id} · ${fmtDateTime(lead.created_at)}`}
+        onClose={onClose}
+      />
+      <div style={{ padding: "22px 26px" }}>
+ 
+        {/* Status banner */}
+        <div style={{
+          marginBottom: 20, padding: "14px 16px", background: s.pill,
+          borderRadius: 12, border: `1.5px solid ${s.pillBorder}`,
+          display: "flex", alignItems: "center", gap: 14,
+        }}>
+          <div style={{
+            width: 38, height: 38, borderRadius: 10,
+            background: `${s.strip}18`, border: `1.5px solid ${s.strip}35`,
+            display: "flex", alignItems: "center", justifyContent: "center",
+            color: s.strip, flexShrink: 0,
+          }}>
+            {TYPE_ICON[lead.type] || <TagIcon />}
+          </div>
+          <div style={{ flex: 1 }}>
+            <p style={{
+              fontSize: 9.5, color: "#b0a890", fontWeight: 600,
+              textTransform: "uppercase", letterSpacing: "0.8px", margin: "0 0 5px",
+            }}>Request status</p>
+            <span style={{
+              background: `${s.strip}16`, color: s.color,
+              border: `1.5px solid ${s.strip}35`,
+              padding: "3px 13px", borderRadius: 999,
+              fontSize: 11, fontWeight: 700,
+              letterSpacing: "0.4px", textTransform: "uppercase",
+            }}>{s.label}</span>
+          </div>
+          <p style={{
+            fontSize: 12.5, color: "#6b6248", lineHeight: 1.65,
+            maxWidth: 220, margin: 0,
+            fontFamily: "'Cormorant Garamond',Georgia,serif", fontStyle: "italic",
+          }}>
+            {lead.status === "NEW" && !lead.assigned_agent_id && "Your request has been received. An admin will assign an agent shortly."}
+            {lead.status === "NEW" && lead.assigned_agent_id  && "An agent is reviewing your request."}
+            {lead.status === "IN_PROGRESS"                    && "Your agent is actively working on this. You will be contacted soon."}
+            {lead.status === "DONE"                           && "Request completed successfully. Thank you!"}
+            {lead.status === "REJECTED"                       && "This request could not be fulfilled. Feel free to submit a new one."}
+          </p>
+        </div>
+ 
+        {/* Details grid */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginBottom: 16 }}>
+          {[
+            { label: "Type",           value: TYPE_LABEL[lead.type] || lead.type },
+            { label: "Source",         value: SOURCE_LABEL[lead.source] || lead.source },
+            { label: "Preferred date", value: fmtDate(lead.preferred_date) },
+            { label: "Assigned agent", value: lead.agent_name || (lead.assigned_agent_id ? `Agent #${lead.assigned_agent_id}` : "Not assigned yet") },
+          ].map(({ label, value }) => (
+            <div key={label} style={{
+              background: "#fff", borderRadius: 11,
+              padding: "11px 14px", border: "1.5px solid #e8e2d6",
+            }}>
+              <p style={{ fontSize: 9.5, color: "#b0a890", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 5 }}>{label}</p>
+              <p style={{ fontSize: 13.5, fontWeight: 600, color: "#1a1714", margin: 0, fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{value}</p>
+            </div>
+          ))}
+        </div>
+ 
+        {/* Property data */}
+        {pd && (
+          <div style={{
+            background: "rgba(201,184,122,0.06)",
+            border: "1.5px solid rgba(201,184,122,0.18)",
+            borderRadius: 12, padding: "14px 16px", marginBottom: 14,
+          }}>
+            <p style={{
+              fontSize: 9.5, fontWeight: 700, color: "#c9b87a",
+              textTransform: "uppercase", letterSpacing: "0.8px",
+              marginBottom: 10, display: "flex", alignItems: "center", gap: 5,
+            }}>
+              <HomeIcon /> Property details
+            </p>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+              {pd.title && (
+                <div style={{
+                  background: "#fff", borderRadius: 8, padding: "8px 12px",
+                  border: "1px solid #e8e2d6", gridColumn: "span 2",
+                }}>
+                  <p style={{ fontSize: 10, color: "#b0a890", margin: "0 0 3px", textTransform: "uppercase", letterSpacing: "0.6px" }}>Title</p>
+                  <p style={{ fontSize: 14, fontWeight: 600, margin: 0, fontFamily: "'Cormorant Garamond',Georgia,serif", color: "#1a1714" }}>{pd.title}</p>
+                </div>
+              )}
+              {[
+                pd.type        && { icon: <TagIcon/>,      text: pd.type },
+                pd.city        && { icon: <PinIcon/>,      text: pd.city },
+                pd.area_sqm    && { icon: <AreaIcon/>,     text: `${pd.area_sqm} m²` },
+                pd.bedrooms    && { icon: <BedIcon/>,      text: `${pd.bedrooms} bedrooms` },
+                pd.bathrooms   && { icon: null,            text: `${pd.bathrooms} bathrooms` },
+                pd.floor       && { icon: null,            text: `Floor ${pd.floor}${pd.total_floors ? ` / ${pd.total_floors}` : ""}` },
+                pd.year_built  && { icon: <CalendarIcon/>, text: `Built: ${pd.year_built}` },
+                pd.price       && {
+                  icon: null,
+                  text: `€${Number(pd.price).toLocaleString("de-DE")} ${pd.currency}${lead.type === "RENT" && pd.price_period ? ` / ${pd.price_period}` : ""}`,
+                  bold: true,
+                },
+                pd.price_per_sqm && { icon: null, text: `€${Number(pd.price_per_sqm).toLocaleString("de-DE")} / m²` },
+              ].filter(Boolean).map((item, i) => (
+                <span key={i} style={{
+                  fontSize: 13, color: "#4a4438",
+                  display: "flex", alignItems: "center", gap: 5,
+                  padding: "6px 10px", background: "#fff",
+                  borderRadius: 8, border: "1px solid #e8e2d6",
+                  fontWeight: item.bold ? 600 : 400,
+                }}>
+                  {item.icon} {item.text}
+                </span>
+              ))}
+            </div>
+            {pd.description && (
+              <div style={{ marginTop: 8, padding: "8px 12px", background: "#fff", borderRadius: 8, border: "1px solid #e8e2d6" }}>
+                <p style={{ fontSize: 10, color: "#b0a890", margin: "0 0 3px", textTransform: "uppercase", letterSpacing: "0.6px" }}>Notes</p>
+                <p style={{ fontSize: 13, color: "#4a4438", margin: 0, lineHeight: 1.6 }}>{pd.description}</p>
+              </div>
+            )}
+          </div>
+        )}
+ 
+        {/* Message */}
+        {lead.message && cleanMsg(lead.message) && (
+          <div style={{ background: "#fff", border: "1.5px solid #e8e2d6", borderRadius: 12, padding: "14px 16px" }}>
+            <p style={{ fontSize: 9.5, color: "#b0a890", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 8 }}>Your message</p>
+            <p style={{ fontSize: 14.5, color: "#3c3830", lineHeight: 1.85, fontStyle: "italic", margin: 0, fontFamily: "'Cormorant Garamond',Georgia,serif" }}>"{cleanMsg(lead.message)}"</p>
+          </div>
+        )}
+ 
+        <div style={{ borderTop: "1px solid #e8e2d6", paddingTop: 16, marginTop: 18, display: "flex", justifyContent: "flex-end" }}>
+          <button onClick={onClose} className="cl-btn" style={{
+            padding: "10px 22px", borderRadius: 10,
+            border: "1.5px solid #e4ddd0", background: "transparent",
+            color: "#6b6248", fontSize: 13.5, fontWeight: 500,
+            cursor: "pointer", fontFamily: "inherit",
+          }}>Close</button>
+        </div>
+      </div>
+    </ModalWrap>
+  );
+}
+ 

--- a/src/components/client/leads/LeadsIcons.jsx
+++ b/src/components/client/leads/LeadsIcons.jsx
@@ -1,0 +1,24 @@
+const Ico = (d, w = 15, sw = 1.8) => (
+  <svg width={w} height={w} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">{d}</svg>
+);
+ 
+export const PlusIcon       = () => Ico(<><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></>, 14, 2.2);
+export const HomeIcon       = () => Ico(<><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></>, 14);
+export const TagIcon        = () => Ico(<><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></>, 14);
+export const KeyIcon        = () => Ico(<><circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2 10.58 12.42M13 7l3 3M18 2l3 3-6 6-3-3"/></>, 14);
+export const ChartIcon      = () => Ico(<><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></>, 14);
+export const CalendarIcon   = () => Ico(<><rect width="18" height="18" x="3" y="4" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></>, 13);
+export const UserIcon       = () => Ico(<><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></>, 13);
+export const PinIcon        = () => Ico(<><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></>, 12);
+export const AreaIcon       = () => Ico(<><path d="M3 3h7v7H3z"/><path d="M14 3h7v7h-7z"/><path d="M14 14h7v7h-7z"/><path d="M3 14h7v7H3z"/></>, 13);
+export const BedIcon        = () => Ico(<><path d="M2 4v16"/><path d="M22 8H2"/><path d="M22 20V8l-4-4H6L2 8"/><path d="M6 8v4"/><path d="M18 8v4"/></>, 13);
+export const ArrowRightIcon = () => Ico(<><path d="m9 18 6-6-6-6"/></>, 13, 2.2);
+export const ClockIcon      = () => Ico(<><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></>, 13);
+ 
+export const TYPE_ICON = {
+  SELL:      <TagIcon />,
+  RENT:      <KeyIcon />,
+  VALUATION: <ChartIcon />,
+};
+ 

--- a/src/components/client/leads/LeadsUI.jsx
+++ b/src/components/client/leads/LeadsUI.jsx
@@ -1,0 +1,145 @@
+import { useEffect } from "react";
+import { LBL } from "./leadsConstants";
+ 
+// ─── Toast ────────────────────────────────────────────────────────────────────
+export function Toast({ msg, type = "success", onDone }) {
+  useEffect(() => { const t = setTimeout(onDone, 3000); return () => clearTimeout(t); }, [onDone]);
+  return (
+    <div style={{
+      position: "fixed", bottom: 26, right: 26, zIndex: 9999,
+      background: "#1a1714", color: type === "error" ? "#e08080" : "#80c0a0",
+      padding: "11px 18px", borderRadius: 12, fontSize: 13,
+      boxShadow: "0 10px 36px rgba(0,0,0,0.32)",
+      border: `1px solid ${type === "error" ? "rgba(224,128,128,0.15)" : "rgba(128,192,160,0.15)"}`,
+      maxWidth: 320, fontFamily: "'DM Sans',sans-serif",
+      animation: "cl-toast 0.2s ease", display: "flex", alignItems: "center", gap: 8,
+    }}>
+      <span style={{ opacity: 0.5, fontSize: 11 }}>{type === "error" ? "✕" : "✓"}</span>
+      {msg}
+    </div>
+  );
+}
+ 
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+export function Skeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} style={{
+          background: "linear-gradient(90deg,#ede9df 25%,#e4ddd0 50%,#ede9df 75%)",
+          backgroundSize: "800px 100%", borderRadius: 14, height: 118,
+          animation: "cl-shimmer 1.5s ease-in-out infinite",
+        }}/>
+      ))}
+    </div>
+  );
+}
+ 
+// ─── Field ────────────────────────────────────────────────────────────────────
+export function Field({ label, children, required, hint }) {
+  return (
+    <div style={{ marginBottom: 13 }}>
+      <label style={LBL}>
+        {label}{required && <span style={{ color: "#c0392b", marginLeft: 2 }}>*</span>}
+      </label>
+      {children}
+      {hint && <p style={{ fontSize: 11.5, color: "#b0a890", marginTop: 4 }}>{hint}</p>}
+    </div>
+  );
+}
+ 
+// ─── ModalWrap ────────────────────────────────────────────────────────────────
+export function ModalWrap({ children, onClose, maxW = 620 }) {
+  useEffect(() => {
+    const h = e => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [onClose]);
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+  return (
+    <div onClick={e => e.target === e.currentTarget && onClose()}
+      style={{
+        position: "fixed", inset: 0, zIndex: 1000,
+        background: "rgba(8,6,4,0.84)", backdropFilter: "blur(14px)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        padding: 20, fontFamily: "'DM Sans',sans-serif",
+      }}>
+      <div style={{
+        width: "100%", maxWidth: maxW, background: "#faf7f2", borderRadius: 18,
+        boxShadow: "0 44px 100px rgba(0,0,0,0.55)", maxHeight: "92vh",
+        overflowY: "auto", animation: "cl-scale-in 0.26s ease",
+      }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+ 
+// ─── Modal Header ─────────────────────────────────────────────────────────────
+export function MH({ title, sub, onClose }) {
+  return (
+    <div style={{
+      background: "linear-gradient(135deg,#141210 0%,#1e1a14 45%,#241e16 100%)",
+      padding: "20px 26px", borderRadius: "18px 18px 0 0",
+      display: "flex", alignItems: "center", justifyContent: "space-between",
+      borderBottom: "1px solid rgba(201,184,122,0.14)",
+      position: "relative", overflow: "hidden",
+    }}>
+      <div style={{
+        position: "absolute", top: 0, left: 0, right: 0, height: "2px",
+        background: "linear-gradient(90deg,transparent,#c9b87a 30%,#c9b87a 70%,transparent)",
+      }}/>
+      <div>
+        <p style={{
+          fontFamily: "'Cormorant Garamond',Georgia,serif", fontWeight: 700,
+          fontSize: 19, margin: "0 0 2px", color: "#f5f0e8", letterSpacing: "-0.2px",
+        }}>{title}</p>
+        {sub && <p style={{ fontSize: 12, color: "rgba(245,240,232,0.38)", margin: 0 }}>{sub}</p>}
+      </div>
+      <button onClick={onClose} style={{
+        background: "rgba(245,240,232,0.07)", backdropFilter: "blur(8px)",
+        border: "1px solid rgba(245,240,232,0.12)", borderRadius: 9,
+        width: 32, height: 32, cursor: "pointer", display: "flex",
+        alignItems: "center", justifyContent: "center",
+        color: "rgba(245,240,232,0.55)", fontSize: 16,
+      }}>×</button>
+    </div>
+  );
+}
+ 
+// ─── Pagination ───────────────────────────────────────────────────────────────
+const PGB = (active, disabled) => ({
+  padding: "7px 13px", borderRadius: 9,
+  border: `1.5px solid ${active ? "#1a1714" : "#e4ddd0"}`,
+  background: active ? "#1a1714" : "transparent",
+  color: active ? "#f5f0e8" : disabled ? "#d4ccbe" : "#6b6248",
+  cursor: disabled ? "not-allowed" : "pointer",
+  fontSize: 13, fontWeight: active ? 600 : 400,
+  fontFamily: "'DM Sans',sans-serif",
+  opacity: disabled ? 0.5 : 1, transition: "all 0.14s",
+});
+ 
+export function Pagination({ page, totalPages, onChange }) {
+  if (totalPages <= 1) return null;
+  const pages   = Array.from({ length: totalPages }, (_, i) => i);
+  const visible = pages.filter(p => p === 0 || p === totalPages - 1 || Math.abs(p - page) <= 1);
+  return (
+    <div style={{ display: "flex", justifyContent: "center", gap: 4, marginTop: 44, flexWrap: "wrap" }}>
+      <button disabled={page === 0} onClick={() => onChange(page - 1)} style={PGB(false, page === 0)}>‹</button>
+      {visible.map((p, i) => {
+        const gap = visible[i - 1] != null && p - visible[i - 1] > 1;
+        return (
+          <span key={p} style={{ display: "flex", gap: 4 }}>
+            {gap && <span style={{ padding: "7px 4px", color: "#b0a890", fontSize: 13 }}>…</span>}
+            <button onClick={() => onChange(p)} style={PGB(p === page, false)}>{p + 1}</button>
+          </span>
+        );
+      })}
+      <button disabled={page === totalPages - 1} onClick={() => onChange(page + 1)} style={PGB(false, page === totalPages - 1)}>›</button>
+    </div>
+  );
+}
+ 

--- a/src/components/client/leads/PropertyFields.jsx
+++ b/src/components/client/leads/PropertyFields.jsx
@@ -1,0 +1,223 @@
+import { Field } from "./LeadsUI";
+import { HomeIcon } from "./LeadsIcons";
+import { TYPE_FIELDS, PROPERTY_TYPES, CURRENCIES, PRICE_PERIODS, INP_S, SEL_S } from "./leadsConstants";
+ 
+export default function PropertyFields({ form, setForm }) {
+  const set = (k, v) => setForm(p => ({
+    ...p,
+    property_data: { ...p.property_data, [k]: v },
+  }));
+ 
+  const pd     = form.property_data || {};
+  const isRent = form.type === "RENT";
+  const fields = TYPE_FIELDS[pd.type || "APARTMENT"] || TYPE_FIELDS.APARTMENT;
+ 
+  const accent = isRent ? "#7eb8a4" : "#c9b87a";
+  const bg     = isRent ? "rgba(126,184,164,0.06)" : "rgba(201,184,122,0.06)";
+  const border = isRent ? "rgba(126,184,164,0.18)" : "rgba(201,184,122,0.18)";
+ 
+  const handlePrice = val => {
+    set("price", val);
+    if (val && pd.area_sqm && Number(pd.area_sqm) > 0)
+      set("price_per_sqm", (Number(val) / Number(pd.area_sqm)).toFixed(2));
+  };
+ 
+  const handleAreaSqm = val => {
+    set("area_sqm", val);
+    if (val && pd.price && Number(val) > 0)
+      set("price_per_sqm", (Number(pd.price) / Number(val)).toFixed(2));
+    else if (val && pd.price_per_sqm && Number(val) > 0)
+      set("price", (Number(pd.price_per_sqm) * Number(val)).toFixed(2));
+  };
+ 
+  const handlePricePerSqm = val => {
+    set("price_per_sqm", val);
+    if (val && pd.area_sqm && Number(pd.area_sqm) > 0)
+      set("price", (Number(val) * Number(pd.area_sqm)).toFixed(2));
+  };
+ 
+  const handleTypeChange = val => {
+    const nf = TYPE_FIELDS[val] || TYPE_FIELDS.APARTMENT;
+    set("type", val);
+    if (!nf.floor)        set("floor", "");
+    if (!nf.total_floors) set("total_floors", "");
+    if (!nf.bedrooms)     set("bedrooms", "");
+    if (!nf.bathrooms)    set("bathrooms", "");
+    if (!nf.year_built)   set("year_built", "");
+  };
+ 
+  const roomCols  = [true, fields.bedrooms, fields.bathrooms].filter(Boolean).length;
+  const floorCols = [fields.floor, fields.total_floors, fields.year_built].filter(Boolean).length;
+  const priceCols = isRent ? 4 : 3;
+ 
+  return (
+    <div style={{
+      marginTop: 8, padding: "16px 14px", background: bg,
+      borderRadius: 12, border: `1.5px solid ${border}`, marginBottom: 14,
+    }}>
+      <p style={{
+        fontSize: 10, fontWeight: 700, color: accent,
+        textTransform: "uppercase", letterSpacing: "1px",
+        marginBottom: 14, display: "flex", alignItems: "center", gap: 6,
+      }}>
+        <HomeIcon /> Property details
+        <span style={{ fontSize: 10, fontWeight: 400, color: "#b0a890", textTransform: "none", letterSpacing: 0 }}>
+          (agent will register in the system)
+        </span>
+      </p>
+ 
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <Field label="Property title" required>
+          <input className="cl-in" style={INP_S}
+            value={pd.title || ""}
+            onChange={e => set("title", e.target.value)}
+            placeholder="e.g. 2+1 Apartment Tirana" />
+        </Field>
+        <Field label="Property type" required>
+          <select className="cl-in" style={SEL_S}
+            value={pd.type || "APARTMENT"}
+            onChange={e => handleTypeChange(e.target.value)}>
+            {PROPERTY_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </Field>
+      </div>
+ 
+      {/* Price block */}
+      <div style={{
+        background: "#fff", border: "1px solid #e8e2d6",
+        borderRadius: 10, padding: "12px 14px", marginBottom: 12,
+      }}>
+        <p style={{
+          fontSize: 10, fontWeight: 700, color: "#9a8c6e",
+          textTransform: "uppercase", letterSpacing: "0.7px", margin: "0 0 10px",
+        }}>
+          💡 Fill any two price fields — the third calculates automatically
+        </p>
+        <div style={{ display: "grid", gridTemplateColumns: `repeat(${priceCols}, 1fr)`, gap: 12 }}>
+          <Field label={isRent ? "Rent price" : "Asking price"} required>
+            <input className="cl-in" style={INP_S} type="number" min="0"
+              value={pd.price || ""}
+              onChange={e => handlePrice(e.target.value)}
+              placeholder={isRent ? "500" : "120000"} />
+          </Field>
+          <Field label="Price per m²">
+            <input className="cl-in" style={INP_S} type="number" min="0"
+              value={pd.price_per_sqm || ""}
+              onChange={e => handlePricePerSqm(e.target.value)}
+              placeholder="1200" />
+          </Field>
+          <Field label="Currency">
+            <select className="cl-in" style={SEL_S}
+              value={pd.currency || "EUR"}
+              onChange={e => set("currency", e.target.value)}>
+              {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </Field>
+          {isRent && (
+            <Field label="Period">
+              <select className="cl-in" style={SEL_S}
+                value={pd.price_period || "MONTHLY"}
+                onChange={e => set("price_period", e.target.value)}>
+                {PRICE_PERIODS.map(p => <option key={p} value={p}>{p}</option>)}
+              </select>
+            </Field>
+          )}
+        </div>
+        {pd.price && pd.area_sqm && pd.price_per_sqm && (
+          <div style={{
+            marginTop: 8, padding: "6px 10px",
+            background: "#f0fdf4", borderRadius: 7, border: "1px solid #a7f3d0",
+            fontSize: 12, color: "#047857", display: "flex", gap: 16, flexWrap: "wrap",
+          }}>
+            <span>Total: <strong>€{Number(pd.price).toLocaleString("de-DE")}</strong></span>
+            <span>Per m²: <strong>€{Number(pd.price_per_sqm).toLocaleString("de-DE")}</strong></span>
+            <span>Area: <strong>{pd.area_sqm} m²</strong></span>
+          </div>
+        )}
+      </div>
+ 
+      {/* Area + Bedrooms + Bathrooms */}
+      <div style={{ display: "grid", gridTemplateColumns: `repeat(${roomCols}, 1fr)`, gap: 12 }}>
+        <Field label="Area (m²)">
+          <input className="cl-in" style={INP_S} type="number" min="0"
+            value={pd.area_sqm || ""}
+            onChange={e => handleAreaSqm(e.target.value)}
+            placeholder="85" />
+        </Field>
+        {fields.bedrooms && (
+          <Field label="Bedrooms">
+            <input className="cl-in" style={INP_S} type="number" min="0"
+              value={pd.bedrooms || ""}
+              onChange={e => set("bedrooms", e.target.value)}
+              placeholder="2" />
+          </Field>
+        )}
+        {fields.bathrooms && (
+          <Field label="Bathrooms">
+            <input className="cl-in" style={INP_S} type="number" min="0"
+              value={pd.bathrooms || ""}
+              onChange={e => set("bathrooms", e.target.value)}
+              placeholder="1" />
+          </Field>
+        )}
+      </div>
+ 
+      {/* Floor + Total floors + Year built */}
+      {floorCols > 0 && (
+        <div style={{ display: "grid", gridTemplateColumns: `repeat(${floorCols}, 1fr)`, gap: 12 }}>
+          {fields.floor && (
+            <Field label="Floor">
+              <input className="cl-in" style={INP_S} type="number"
+                value={pd.floor || ""}
+                onChange={e => set("floor", e.target.value)}
+                placeholder="3" />
+            </Field>
+          )}
+          {fields.total_floors && (
+            <Field label="Total floors">
+              <input className="cl-in" style={INP_S} type="number" min="1"
+                value={pd.total_floors || ""}
+                onChange={e => set("total_floors", e.target.value)}
+                placeholder="8" />
+            </Field>
+          )}
+          {fields.year_built && (
+            <Field label="Year built">
+              <input className="cl-in" style={INP_S}
+                type="number" min="1900" max={new Date().getFullYear()}
+                value={pd.year_built || ""}
+                onChange={e => set("year_built", e.target.value)}
+                placeholder="2015" />
+            </Field>
+          )}
+        </div>
+      )}
+ 
+      {/* City + Street */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <Field label="City" required>
+          <input className="cl-in" style={INP_S}
+            value={pd.city || ""}
+            onChange={e => set("city", e.target.value)}
+            placeholder="Tirana" />
+        </Field>
+        <Field label="Street / Area">
+          <input className="cl-in" style={INP_S}
+            value={pd.street || ""}
+            onChange={e => set("street", e.target.value)}
+            placeholder="Rr. e Durrësit" />
+        </Field>
+      </div>
+ 
+      <Field label="Description" hint="Condition, features, included appliances, etc.">
+        <textarea className="cl-in"
+          value={pd.description || ""}
+          onChange={e => set("description", e.target.value)}
+          rows={2}
+          placeholder="Newly renovated, equipped kitchen, parking..."
+          style={{ ...INP_S, resize: "vertical" }} />
+      </Field>
+    </div>
+  );
+}
+ 

--- a/src/components/client/leads/leadsConstants.js
+++ b/src/components/client/leads/leadsConstants.js
@@ -1,0 +1,89 @@
+// ─── Constants ────────────────────────────────────────────────────────────────
+export const LEAD_TYPES     = ["SELL", "RENT", "VALUATION"];
+export const LEAD_SOURCES   = ["WEBSITE", "PHONE", "EMAIL", "REFERRAL", "SOCIAL"];
+export const PROPERTY_TYPES = ["APARTMENT", "HOUSE", "VILLA", "COMMERCIAL", "LAND", "OFFICE"];
+export const CURRENCIES     = ["EUR", "USD", "ALL", "GBP", "CHF"];
+export const PRICE_PERIODS  = ["MONTHLY", "YEARLY", "DAILY", "WEEKLY"];
+ 
+export const TYPE_FIELDS = {
+  APARTMENT:  { floor: true,  total_floors: true,  bedrooms: true,  bathrooms: true,  year_built: true,  area_sqm: true },
+  HOUSE:      { floor: false, total_floors: true,  bedrooms: true,  bathrooms: true,  year_built: true,  area_sqm: true },
+  VILLA:      { floor: false, total_floors: true,  bedrooms: true,  bathrooms: true,  year_built: true,  area_sqm: true },
+  COMMERCIAL: { floor: true,  total_floors: true,  bedrooms: false, bathrooms: false, year_built: true,  area_sqm: true },
+  LAND:       { floor: false, total_floors: false, bedrooms: false, bathrooms: false, year_built: false, area_sqm: true },
+  OFFICE:     { floor: true,  total_floors: true,  bedrooms: false, bathrooms: true,  year_built: true,  area_sqm: true },
+};
+ 
+export const TYPE_LABEL = {
+  SELL:      "Sell a property",
+  RENT:      "Rent out a property",
+  VALUATION: "Property valuation",
+};
+ 
+export const SOURCE_LABEL = {
+  WEBSITE:  "Website",
+  PHONE:    "Phone",
+  EMAIL:    "Email",
+  REFERRAL: "Referral",
+  SOCIAL:   "Social Media",
+};
+ 
+export const STATUS = {
+  NEW:         { strip: "#c9b87a", pill: "rgba(201,184,122,0.12)", pillBorder: "rgba(201,184,122,0.28)", color: "#a8923e", label: "New"         },
+  IN_PROGRESS: { strip: "#7eb8a4", pill: "rgba(126,184,164,0.12)", pillBorder: "rgba(126,184,164,0.28)", color: "#2a8068", label: "In Progress" },
+  DONE:        { strip: "#a4b07e", pill: "rgba(164,176,126,0.12)", pillBorder: "rgba(164,176,126,0.28)", color: "#5a6a38", label: "Done"        },
+  REJECTED:    { strip: "#c07050", pill: "rgba(192,112,80,0.12)",  pillBorder: "rgba(192,112,80,0.28)",  color: "#8b4030", label: "Rejected"    },
+};
+ 
+export const fmtDate     = d => d ? new Date(d).toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric" }) : "—";
+export const fmtDateTime = d => d ? new Date(d).toLocaleString("en-GB",     { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" }) : "—";
+ 
+export const parsePD = msg => {
+  if (!msg) return null;
+  try {
+    const marker = "__PROPERTY_DATA__:";
+    const idx    = msg.indexOf(marker);
+    if (idx === -1) return null;
+    return JSON.parse(msg.substring(idx + marker.length));
+  } catch { return null; }
+};
+ 
+export const cleanMsg = msg => {
+  if (!msg) return "";
+  const idx = msg.indexOf("\n--- Property Details ---");
+  if (idx !== -1) return msg.substring(0, idx).trim();
+  const idx2 = msg.indexOf("\n__PROPERTY_DATA__:");
+  if (idx2 !== -1) return msg.substring(0, idx2).trim();
+  return msg;
+};
+ 
+export const CSS = `
+  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=DM+Sans:wght@300;400;500;600&display=swap');
+  .cl * { box-sizing: border-box; }
+  .cl { font-family: 'DM Sans', system-ui, sans-serif; background: #f2ede4; min-height: 100vh; }
+  .cl-card { transition: transform 0.25s cubic-bezier(0.25,0.46,0.45,0.94), box-shadow 0.25s ease; }
+  .cl-card:hover { transform: translateY(-4px); box-shadow: 0 20px 48px rgba(20,16,10,0.13) !important; }
+  .cl-btn { transition: all 0.17s ease; }
+  .cl-btn:hover:not(:disabled) { opacity: 0.86; transform: translateY(-1px); }
+  .cl-in:focus { border-color: #8a7d5e !important; box-shadow: 0 0 0 3px rgba(138,125,94,0.13) !important; outline: none; }
+  @keyframes cl-fade-up  { from{opacity:0;transform:translateY(18px)} to{opacity:1;transform:translateY(0)} }
+  @keyframes cl-scale-in { from{opacity:0;transform:scale(0.95) translateY(12px)} to{opacity:1;transform:scale(1) translateY(0)} }
+  @keyframes cl-spin     { to{transform:rotate(360deg)} }
+  @keyframes cl-toast    { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
+  @keyframes cl-card-in  { from{opacity:0;transform:translateY(20px)} to{opacity:1;transform:translateY(0)} }
+  @keyframes cl-shimmer  { 0%{background-position:-800px 0} 100%{background-position:800px 0} }
+`;
+ 
+export const INP_S = {
+  width: "100%", padding: "10px 13px", border: "1.5px solid #e4ddd0",
+  borderRadius: 10, fontSize: 13.5, color: "#1a1714",
+  background: "#fff", fontFamily: "'DM Sans',sans-serif",
+  boxSizing: "border-box", outline: "none", transition: "border-color 0.2s",
+};
+export const SEL_S = { ...INP_S, cursor: "pointer" };
+export const LBL = {
+  display: "block", fontSize: 10.5, fontWeight: 600, color: "#9a8c6e",
+  textTransform: "uppercase", letterSpacing: "0.7px", marginBottom: 6,
+  fontFamily: "'DM Sans',sans-serif",
+};
+ 

--- a/src/components/client/profile/ProfileSidebar.jsx
+++ b/src/components/client/profile/ProfileSidebar.jsx
@@ -1,0 +1,70 @@
+import { I } from "./profileConstants";
+ 
+export default function ProfileSidebar({ fullName, userInfo, profile }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+ 
+      {/* Summary card */}
+      <div style={{ background: "#fff", border: "1px solid #e4ddd2", padding: "22px 20px" }}>
+        <p style={{ fontSize: "10px", fontWeight: 600, color: "#a09080", textTransform: "uppercase", letterSpacing: "1.1px", margin: "0 0 16px", fontFamily: "'DM Sans',sans-serif" }}>Overview</p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {[
+            { icon: I.user(13),  label: "Name",  val: fullName || "—"                },
+            { icon: I.mail(13),  label: "Email", val: userInfo?.email || "—"          },
+            { icon: I.phone(13), label: "Phone", val: profile?.phone || "—"           },
+            { icon: I.pin(13),   label: "City",  val: profile?.preferred_city || "—" },
+            { icon: I.home(13),  label: "Type",  val: profile?.preferred_type || "—" },
+          ].map(row => (
+            <div key={row.label} style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+              <span style={{ color: "#a09080", marginTop: 2, flexShrink: 0 }}>{row.icon}</span>
+              <div style={{ minWidth: 0 }}>
+                <p style={{ fontSize: "10px", fontWeight: 600, color: "#b0a890", textTransform: "uppercase", letterSpacing: ".8px", margin: "0 0 1px", fontFamily: "'DM Sans',sans-serif" }}>{row.label}</p>
+                <p style={{ fontSize: "13px", color: row.val === "—" ? "#c0b8a8" : "#1a1a12", margin: 0, fontFamily: "'DM Sans',sans-serif", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.val}</p>
+              </div>
+            </div>
+          ))}
+          {(profile?.budget_min || profile?.budget_max) && (
+            <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+              <span style={{ color: "#a09080", marginTop: 2, flexShrink: 0 }}>{I.euro(13)}</span>
+              <div>
+                <p style={{ fontSize: "10px", fontWeight: 600, color: "#b0a890", textTransform: "uppercase", letterSpacing: ".8px", margin: "0 0 1px", fontFamily: "'DM Sans',sans-serif" }}>Budget</p>
+                <p style={{ fontSize: "13px", color: "#1a1a12", margin: 0, fontFamily: "'DM Sans',sans-serif" }}>
+                  €{profile.budget_min ? Number(profile.budget_min).toLocaleString("de-DE") : "—"}
+                  <span style={{ color: "#c0b0a0", margin: "0 4px" }}>–</span>
+                  €{profile.budget_max ? Number(profile.budget_max).toLocaleString("de-DE") : "—"}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+ 
+      {/* Account status card */}
+      <div style={{ background: "#fff", border: "1px solid #e4ddd2", padding: "18px 20px" }}>
+        <p style={{ fontSize: "10px", fontWeight: 600, color: "#a09080", textTransform: "uppercase", letterSpacing: "1.1px", margin: "0 0 14px", fontFamily: "'DM Sans',sans-serif" }}>Account Status</p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span style={{ fontSize: "12.5px", color: "#8a8070", fontFamily: "'DM Sans',sans-serif" }}>Role</span>
+            <span style={{ fontSize: "12.5px", color: "#2a5040", fontWeight: 500, fontFamily: "'DM Sans',sans-serif" }}>Client</span>
+          </div>
+          <div style={{ height: 1, background: "#f0e8de" }}/>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <span style={{ fontSize: "12.5px", color: "#8a8070", fontFamily: "'DM Sans',sans-serif" }}>Status</span>
+            <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+              <div style={{ width: 6, height: 6, borderRadius: "50%", background: userInfo?.is_active ? "#2a8040" : "#c04040" }}/>
+              <span style={{ fontSize: "12.5px", color: userInfo?.is_active ? "#2a5040" : "#8b3010", fontWeight: 500, fontFamily: "'DM Sans',sans-serif" }}>{userInfo?.is_active ? "Active" : "Inactive"}</span>
+            </div>
+          </div>
+          {userInfo?.tenant_id && <>
+            <div style={{ height: 1, background: "#f0e8de" }}/>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <span style={{ fontSize: "12.5px", color: "#8a8070", fontFamily: "'DM Sans',sans-serif" }}>Tenant</span>
+              <span style={{ fontSize: "12px", color: "#6b6040", fontFamily: "'DM Sans',sans-serif" }}>#{userInfo.tenant_id}</span>
+            </div>
+          </>}
+        </div>
+      </div>
+    </div>
+  );
+}
+ 

--- a/src/components/client/profile/ProfileTabs.jsx
+++ b/src/components/client/profile/ProfileTabs.jsx
@@ -1,0 +1,160 @@
+import { Field, EuroInput, Section, SaveBtn, Banner, MetaGrid, PwInput } from "./ProfileUI";
+ 
+// ─── Profile Tab ──────────────────────────────────────────────────────────────
+export function ProfileTab({ profile, profileForm, setP, saving, onSave }) {
+  return (
+    <>
+      {!profile && (
+        <Banner type="info">
+          Fill in your preferences so we can match you with the best properties.
+        </Banner>
+      )}
+ 
+      <Section title="Contact Details"/>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <Field label="Phone number">
+          <input className="cp-inp" value={profileForm.phone} onChange={e => setP("phone", e.target.value)} placeholder="+383 44 123 456"/>
+        </Field>
+        <Field label="Preferred contact">
+          <select className="cp-inp cp-sel" value={profileForm.preferred_contact} onChange={e => setP("preferred_contact", e.target.value)}>
+            <option value="EMAIL">Email</option>
+            <option value="PHONE">Phone</option>
+            <option value="WHATSAPP">WhatsApp</option>
+          </select>
+        </Field>
+      </div>
+ 
+      <Section title="Property Preferences"/>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <Field label="Property type" hint="APARTMENT · HOUSE · VILLA · COMMERCIAL">
+          <input className="cp-inp" value={profileForm.preferred_type} onChange={e => setP("preferred_type", e.target.value)} placeholder="e.g. APARTMENT"/>
+        </Field>
+        <Field label="Preferred city">
+          <input className="cp-inp" value={profileForm.preferred_city} onChange={e => setP("preferred_city", e.target.value)} placeholder="e.g. Tirana"/>
+        </Field>
+      </div>
+ 
+      <Section title="Budget Range (EUR)"/>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <Field label="Minimum">
+          <EuroInput value={profileForm.budget_min} onChange={e => setP("budget_min", e.target.value)} placeholder="50,000"/>
+        </Field>
+        <Field label="Maximum">
+          <EuroInput value={profileForm.budget_max} onChange={e => setP("budget_max", e.target.value)} placeholder="500,000"/>
+        </Field>
+      </div>
+      {profileForm.budget_min && profileForm.budget_max && Number(profileForm.budget_min) > Number(profileForm.budget_max) && (
+        <Banner type="warn">Minimum budget cannot exceed maximum budget.</Banner>
+      )}
+ 
+      <Section title="Profile Photo"/>
+      <Field label="Photo URL">
+        <input className="cp-inp" value={profileForm.photo_url} onChange={e => setP("photo_url", e.target.value)} placeholder="https://…"/>
+      </Field>
+      {profileForm.photo_url && (
+        <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 16px", background: "#f7f4ee", border: "1px solid #e4ddd2", marginBottom: 20, marginTop: -14 }}>
+          <img src={profileForm.photo_url} alt="preview" style={{ width: 40, height: 40, borderRadius: "50%", objectFit: "cover", border: "1px solid #ddd6c8" }} onError={e => { e.target.style.display = "none"; }}/>
+          <span style={{ fontSize: "12px", color: "#9a8c7a", fontFamily: "'DM Sans',sans-serif" }}>Photo preview</span>
+        </div>
+      )}
+ 
+      <div style={{ display: "flex", justifyContent: "flex-end", borderTop: "1px solid #efe8de", paddingTop: 22, marginTop: 8 }}>
+        <SaveBtn onClick={onSave} loading={saving} label={profile ? "Save Changes" : "Create Profile"}/>
+      </div>
+    </>
+  );
+}
+ 
+// ─── Account Tab ──────────────────────────────────────────────────────────────
+export function AccountTab({ userInfo, userForm, setU, savingUser, onSave }) {
+  return (
+    <>
+      <Section title="Personal Information"/>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <Field label="First name" required>
+          <input className="cp-inp" value={userForm.first_name} onChange={e => setU("first_name", e.target.value)} placeholder="First name"/>
+        </Field>
+        <Field label="Last name" required>
+          <input className="cp-inp" value={userForm.last_name} onChange={e => setU("last_name", e.target.value)} placeholder="Last name"/>
+        </Field>
+      </div>
+ 
+      <Section title="Login Details"/>
+      <Field label="Email address" required>
+        <input className="cp-inp" type="email" value={userForm.email} onChange={e => setU("email", e.target.value)} placeholder="your@email.com"/>
+      </Field>
+ 
+      <Section title="Account Information"/>
+      <MetaGrid userInfo={userInfo}/>
+ 
+      <div style={{ display: "flex", justifyContent: "flex-end", borderTop: "1px solid #efe8de", paddingTop: 22 }}>
+        <SaveBtn onClick={onSave} loading={savingUser} label="Save Changes"/>
+      </div>
+    </>
+  );
+}
+ 
+// ─── Password Tab ─────────────────────────────────────────────────────────────
+export function PasswordTab({ pwForm, setPw, savingPw, onSave }) {
+  const pwMatch    = pwForm.new_password && pwForm.confirm && pwForm.new_password === pwForm.confirm && pwForm.new_password.length >= 8;
+  const pwMismatch = pwForm.confirm && pwForm.new_password !== pwForm.confirm;
+  const pwShort    = pwForm.new_password && pwForm.new_password.length < 8;
+ 
+  return (
+    <>
+      <Banner type="info">
+        Use at least 8 characters. Mix letters, numbers, and symbols for a stronger password.
+      </Banner>
+ 
+      <Section title="Current Password"/>
+      <Field label="Current password" required>
+        <PwInput value={pwForm.current_password} onChange={e => setPw("current_password", e.target.value)} placeholder="Enter your current password"/>
+      </Field>
+ 
+      <Section title="New Password"/>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <Field label="New password" required>
+          <PwInput value={pwForm.new_password} onChange={e => setPw("new_password", e.target.value)} placeholder="Min. 8 characters"/>
+        </Field>
+        <Field label="Confirm new password" required>
+          <PwInput value={pwForm.confirm} onChange={e => setPw("confirm", e.target.value)} placeholder="Repeat new password"/>
+        </Field>
+      </div>
+ 
+      {/* Live feedback */}
+      <div style={{ marginTop: -8, marginBottom: 20, display: "flex", flexDirection: "column", gap: 5 }}>
+        {pwShort    && <p style={{ fontSize: "12px", color: "#9a7010", display: "flex", alignItems: "center", gap: 5, margin: 0, fontFamily: "'DM Sans',sans-serif" }}>⚠ Password must be at least 8 characters</p>}
+        {pwMismatch && <p style={{ fontSize: "12px", color: "#b04040", display: "flex", alignItems: "center", gap: 5, margin: 0, fontFamily: "'DM Sans',sans-serif" }}>⚠ Passwords do not match</p>}
+        {pwMatch    && <p style={{ fontSize: "12px", color: "#2a6040", display: "flex", alignItems: "center", gap: 5, margin: 0, fontFamily: "'DM Sans',sans-serif" }}>✓ Passwords match</p>}
+      </div>
+ 
+      {/* Strength bar */}
+      {pwForm.new_password && (() => {
+        const len    = pwForm.new_password.length;
+        const hasNum = /\d/.test(pwForm.new_password);
+        const hasSym = /[^a-zA-Z0-9]/.test(pwForm.new_password);
+        const score  = (len >= 8 ? 1 : 0) + (len >= 12 ? 1 : 0) + hasNum + hasSym;
+        const labels = ["", "Weak", "Fair", "Good", "Strong"];
+        const colors = ["", "#c04040", "#d08020", "#8a9040", "#2a6040"];
+        return (
+          <div style={{ marginBottom: 20 }}>
+            <div style={{ height: 3, background: "#ebe4d8", borderRadius: 0, overflow: "hidden", marginBottom: 6 }}>
+              <div style={{ height: "100%", width: `${score * 25}%`, background: colors[score], transition: "width .3s ease" }}/>
+            </div>
+            {score > 0 && <p style={{ fontSize: "11px", color: colors[score], fontFamily: "'DM Sans',sans-serif", fontWeight: 500 }}>{labels[score]}</p>}
+          </div>
+        );
+      })()}
+ 
+      <div style={{ display: "flex", justifyContent: "flex-end", borderTop: "1px solid #efe8de", paddingTop: 22 }}>
+        <SaveBtn
+          onClick={onSave}
+          disabled={!pwForm.current_password || !pwForm.new_password || pwMismatch || pwShort}
+          loading={savingPw}
+          label="Change Password"
+        />
+      </div>
+    </>
+  );
+}
+ 

--- a/src/components/client/profile/ProfileUI.jsx
+++ b/src/components/client/profile/ProfileUI.jsx
@@ -1,0 +1,163 @@
+import { useState, useEffect } from "react";
+import { I } from "./profileConstants";
+ 
+// ─── Toast ────────────────────────────────────────────────────────────────────
+export function Toast({ msg, type = "success", onDone }) {
+  useEffect(() => { const t = setTimeout(onDone, 3400); return () => clearTimeout(t); }, [onDone]);
+  return (
+    <div style={{
+      position: "fixed", bottom: 28, right: 28, zIndex: 9999,
+      background: "#1a1a12", color: type === "error" ? "#f0a0a0" : "#a0c8a0",
+      padding: "14px 20px", borderRadius: 0, fontSize: 13, fontWeight: 400,
+      fontFamily: "'DM Sans',sans-serif",
+      boxShadow: "0 12px 40px rgba(0,0,0,0.32)",
+      border: `1px solid ${type === "error" ? "rgba(240,160,160,.18)" : "rgba(160,200,160,.18)"}`,
+      maxWidth: 340, display: "flex", alignItems: "center", gap: 10,
+      animation: "cp-up .25s ease",
+    }}>
+      <span style={{ opacity: .7 }}>{type === "error" ? I.warn(13) : I.check(13)}</span>
+      {msg}
+    </div>
+  );
+}
+ 
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+export function Skeleton() {
+  const bar = (h, w = "100%", mb = 0) => (
+    <div style={{ height: h, width: w, background: "#e8e2d6", borderRadius: 0, marginBottom: mb, animation: "cp-pulse 1.6s ease infinite" }}/>
+  );
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "260px 1fr", gap: 24 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        {bar(72)} {bar(52)} {bar(52)} {bar(52)}
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12, padding: "32px", background: "#fff", border: "1px solid #e4ddd2" }}>
+        {bar(28, "60%", 20)} {bar(16, "100%", 8)} {bar(16, "80%", 24)} {bar(44, "100%", 8)} {bar(44, "100%", 8)} {bar(44, "100%")}
+      </div>
+    </div>
+  );
+}
+ 
+// ─── Avatar ───────────────────────────────────────────────────────────────────
+export function Avatar({ photoUrl, name, size = 68 }) {
+  const initials = name
+    ? name.trim().split(" ").slice(0, 2).map(w => w[0]?.toUpperCase()).join("")
+    : "?";
+  if (photoUrl) return (
+    <img src={photoUrl} alt={name} style={{ width: size, height: size, borderRadius: "50%", objectFit: "cover", border: "2px solid rgba(255,255,255,.2)", flexShrink: 0 }}/>
+  );
+  return (
+    <div style={{ width: size, height: size, borderRadius: "50%", background: "rgba(255,255,255,.1)", border: "2px solid rgba(255,255,255,.18)", display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,.85)", fontSize: size * .3, fontWeight: 600, fontFamily: "'Cormorant Garamond',Georgia,serif", flexShrink: 0, letterSpacing: ".5px" }}>
+      {initials}
+    </div>
+  );
+}
+ 
+// ─── Password input with toggle ───────────────────────────────────────────────
+export function PwInput({ value, onChange, placeholder }) {
+  const [show, setShow] = useState(false);
+  return (
+    <div style={{ position: "relative" }}>
+      <input className="cp-inp" type={show ? "text" : "password"} value={value} onChange={onChange}
+        placeholder={placeholder} style={{ paddingRight: 42 }}/>
+      <button onClick={() => setShow(p => !p)}
+        style={{ position: "absolute", right: 12, top: "50%", transform: "translateY(-50%)", background: "none", border: "none", cursor: "pointer", color: "#9a8c6e", display: "flex", alignItems: "center", padding: 0, transition: "color .15s" }}
+        tabIndex={-1}>
+        {show ? I.eyeOff(14) : I.eye(14)}
+      </button>
+    </div>
+  );
+}
+ 
+// ─── Field wrapper ────────────────────────────────────────────────────────────
+export function Field({ label, children, hint, required }) {
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <label style={{ display: "block", fontSize: "10.5px", fontWeight: 600, color: "#8a8070", textTransform: "uppercase", letterSpacing: "1px", marginBottom: 8, fontFamily: "'DM Sans',sans-serif" }}>
+        {label}{required && <span style={{ color: "#b84040", marginLeft: 3 }}>*</span>}
+      </label>
+      {children}
+      {hint && <p style={{ fontSize: 12, color: "#aaa090", marginTop: 6, fontFamily: "'DM Sans',sans-serif", lineHeight: 1.5 }}>{hint}</p>}
+    </div>
+  );
+}
+ 
+// ─── Euro prefix input ────────────────────────────────────────────────────────
+export function EuroInput({ value, onChange, placeholder }) {
+  return (
+    <div style={{ position: "relative" }}>
+      <span style={{ position: "absolute", left: 14, top: "50%", transform: "translateY(-50%)", color: "#9a8c6e", fontSize: 13, fontFamily: "'DM Sans',sans-serif", pointerEvents: "none", userSelect: "none" }}>€</span>
+      <input className="cp-inp" type="number" min="0" value={value} onChange={onChange} placeholder={placeholder} style={{ paddingLeft: 28 }}/>
+    </div>
+  );
+}
+ 
+// ─── Section label ────────────────────────────────────────────────────────────
+export function Section({ title }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 14, margin: "28px 0 20px" }}>
+      <span style={{ fontSize: "10px", fontWeight: 600, color: "#a09080", textTransform: "uppercase", letterSpacing: "1.2px", fontFamily: "'DM Sans',sans-serif", whiteSpace: "nowrap" }}>{title}</span>
+      <div style={{ flex: 1, height: 1, background: "#ebe4d8" }}/>
+    </div>
+  );
+}
+ 
+// ─── Stat chip ────────────────────────────────────────────────────────────────
+export function StatChip({ icon, value }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 7, padding: "7px 14px", background: "rgba(255,255,255,.07)", border: "1px solid rgba(255,255,255,.12)", borderRadius: 0, color: "rgba(255,255,255,.65)", fontSize: "12.5px", fontFamily: "'DM Sans',sans-serif", letterSpacing: ".1px" }}>
+      <span style={{ opacity: .55 }}>{icon}</span>
+      {value}
+    </div>
+  );
+}
+ 
+// ─── Save button ──────────────────────────────────────────────────────────────
+export function SaveBtn({ onClick, disabled, label, loading: l }) {
+  return (
+    <button className="cp-save" onClick={onClick} disabled={disabled || l}
+      style={{ padding: "11px 28px", borderRadius: 0, border: "none", background: disabled || l ? "#b0a890" : "#1a1a12", color: "#f4f1ea", fontSize: "13px", fontWeight: 500, cursor: disabled || l ? "not-allowed" : "pointer", fontFamily: "'DM Sans',sans-serif", letterSpacing: ".3px", display: "flex", alignItems: "center", gap: 9, opacity: disabled || l ? .6 : 1, boxShadow: disabled || l ? "none" : "0 4px 16px rgba(26,26,18,.22)" }}>
+      {l ? (
+        <><div style={{ width: 13, height: 13, border: "1.5px solid rgba(244,241,234,.3)", borderTop: "1.5px solid #f4f1ea", borderRadius: "50%", animation: "cp-spin .7s linear infinite" }}/> Saving…</>
+      ) : (
+        <>{label} <span style={{ opacity: .5 }}>{I.arrowR(13)}</span></>
+      )}
+    </button>
+  );
+}
+ 
+// ─── Banner ───────────────────────────────────────────────────────────────────
+export function Banner({ type = "info", children }) {
+  const cfg = {
+    info:    { bg: "#f7f4ee", border: "#ddd6c8", color: "#6b6040", icon: I.info()    },
+    warn:    { bg: "#fdf6e8", border: "#e8c880", color: "#7a5a10", icon: I.warn()    },
+    success: { bg: "#f0f8f2", border: "#b8d8c0", color: "#2a5840", icon: I.check()  },
+    error:   { bg: "#fef2f2", border: "#e8b8b8", color: "#8b2020", icon: I.warn()   },
+  }[type];
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", gap: 10, padding: "12px 16px", background: cfg.bg, border: `1px solid ${cfg.border}`, borderRadius: 0, marginBottom: 20, fontSize: "13px", color: cfg.color, fontFamily: "'DM Sans',sans-serif", lineHeight: 1.55 }}>
+      <span style={{ marginTop: 1, opacity: .8 }}>{cfg.icon}</span>
+      {children}
+    </div>
+  );
+}
+ 
+// ─── Meta grid ───────────────────────────────────────────────────────────────
+export function MetaGrid({ userInfo }) {
+  const items = [
+    { label: "Role",      value: "Client",                                             color: "#2a5040" },
+    { label: "Status",    value: userInfo?.is_active ? "Active" : "Inactive",          color: userInfo?.is_active ? "#2a5040" : "#8b3010" },
+    { label: "Tenant ID", value: userInfo?.tenant_id ? `#${userInfo.tenant_id}` : "—", color: "#6b6040" },
+  ];
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(3,1fr)", gap: 10, marginBottom: 24 }}>
+      {items.map(item => (
+        <div key={item.label} style={{ padding: "14px 16px", background: "#f7f4ee", border: "1px solid #e4ddd2" }}>
+          <p style={{ fontSize: "10px", fontWeight: 600, color: "#a09080", textTransform: "uppercase", letterSpacing: "1px", margin: "0 0 5px", fontFamily: "'DM Sans',sans-serif" }}>{item.label}</p>
+          <p style={{ fontSize: 14, fontWeight: 500, color: item.color, margin: 0, fontFamily: "'DM Sans',sans-serif" }}>{item.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+ 

--- a/src/components/client/profile/profileConstants.jsx
+++ b/src/components/client/profile/profileConstants.jsx
@@ -1,0 +1,39 @@
+export const GLOBAL_CSS = `
+  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&family=DM+Sans:ital,wght@0,300;0,400;0,500;0,600;1,300&display=swap');
+ 
+  .cp-root { font-family: 'DM Sans', system-ui, sans-serif; background: #f2efe8; min-height: 100vh; color: #1a1a12; }
+  .cp-root * { box-sizing: border-box; }
+ 
+  .cp-inp { width:100%; padding:11px 14px; border:1px solid #ddd6c8; border-radius:0; font-size:14px; color:#1a1a12; background:#fff; outline:none; font-family:'DM Sans',sans-serif; transition:border-color .15s,box-shadow .15s; }
+  .cp-inp:focus { border-color:#6b6340; box-shadow:0 0 0 3px rgba(107,99,64,.1); }
+  .cp-inp::placeholder { color:#b8b0a0; }
+  .cp-sel { cursor:pointer; }
+ 
+  .cp-tab { transition:all .15s ease; cursor:pointer; }
+  .cp-tab:hover { background:#f7f4ee !important; }
+ 
+  .cp-save { transition:all .18s ease; }
+  .cp-save:hover:not(:disabled) { background:#2a2a18 !important; transform:translateY(-1px); box-shadow:0 6px 20px rgba(28,28,16,.25) !important; }
+  .cp-save:active:not(:disabled) { transform:translateY(0); }
+ 
+  @keyframes cp-up   { from{opacity:0;transform:translateY(14px)} to{opacity:1;transform:translateY(0)} }
+  @keyframes cp-spin { to{transform:rotate(360deg)} }
+  @keyframes cp-pulse{ 0%,100%{opacity:.4} 50%{opacity:.85} }
+`;
+ 
+export const I = {
+  user:  (s = 16) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>,
+  mail:  (s = 16) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>,
+  lock:  (s = 16) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"><rect width="18" height="11" x="3" y="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>,
+  pin:   (s = 13) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>,
+  home:  (s = 13) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>,
+  euro:  (s = 13) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 10h12"/><path d="M4 14h9"/><path d="M19 6a7 7 0 1 0 0 12"/></svg>,
+  phone: (s = 13) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.69 13 19.79 19.79 0 0 1 1.61 4.38 2 2 0 0 1 3.6 2h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L7.91 9.91a16 16 0 0 0 6.18 6.18l.91-.91a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"/></svg>,
+  check: (s = 13) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>,
+  warn:  (s = 13) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>,
+  info:  (s = 13) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>,
+  eye:   (s = 14) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>,
+  eyeOff:(s = 14) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>,
+  arrowR:(s = 14) => <svg width={s} height={s} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>,
+};
+ 

--- a/src/components/client/salecontracts/ContractComponents.jsx
+++ b/src/components/client/salecontracts/ContractComponents.jsx
@@ -1,0 +1,209 @@
+import { useState, useEffect } from "react";
+import api from "../../../api/axios";
+import { fmtMoney, fmtDate, daysUntil, getContractStatus, getType, getPaymentStatus } from "./saleConstants";
+ 
+// ─── Contract Card ─────────────────────────────────────────────────────────────
+export function ContractCard({ contract: c, idx, onDetail, onPayments }) {
+  const st   = getContractStatus(c.status);
+  const days = daysUntil(c.handover_date);
+  return (
+    <div className="msc-card" style={{ background: "#fff", borderRadius: 14, border: "1.5px solid #ece6da", overflow: "hidden", boxShadow: "0 2px 16px rgba(20,16,10,0.07)", animation: `msc-card-in 0.36s ease ${Math.min(idx * 0.06, 0.4)}s both` }}>
+      <div style={{ height: 4, background: st.strip }} />
+      <div style={{ padding: "18px 22px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, marginBottom: 14, flexWrap: "wrap" }}>
+          <div>
+            <p style={{ fontSize: 10, fontWeight: 600, color: "#b0a890", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 4 }}>Sale Contract #{c.id} · Property #{c.property_id}</p>
+            <p style={{ fontSize: 24, fontWeight: 700, color: "#1a1714", margin: 0, fontFamily: "'Cormorant Garamond',Georgia,serif", letterSpacing: "-0.3px" }}>{fmtMoney(c.sale_price, c.currency)}</p>
+          </div>
+          <span style={{ background: st.bg, color: st.color, border: `1px solid ${st.border}`, padding: "4px 13px", borderRadius: 999, fontSize: 10.5, fontWeight: 700, flexShrink: 0, display: "flex", alignItems: "center", gap: 5 }}>{st.icon} {st.label}</span>
+        </div>
+        <div style={{ display: "flex", gap: 20, flexWrap: "wrap", marginBottom: 14 }}>
+          {[{ label: "Contract Date", value: fmtDate(c.contract_date) }, { label: "Handover Date", value: fmtDate(c.handover_date) }].map(({ label, value }) => (
+            <div key={label}>
+              <p style={{ fontSize: 10, color: "#b0a890", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.7px", marginBottom: 3 }}>{label}</p>
+              <p style={{ fontSize: 13.5, color: "#4a4438", margin: 0, fontWeight: 500 }}>{value}</p>
+            </div>
+          ))}
+          {days !== null && c.status !== "COMPLETED" && c.status !== "CANCELLED" && (
+            <div style={{ marginLeft: "auto" }}>
+              <span style={{ fontSize: 11.5, fontWeight: 600, color: days < 0 ? "#d4855a" : days <= 7 ? "#c9b87a" : "#2a6049", background: days < 0 ? "rgba(212,133,90,0.08)" : days <= 7 ? "rgba(201,184,122,0.08)" : "rgba(126,184,164,0.08)", border: `1px solid ${days < 0 ? "rgba(212,133,90,0.22)" : days <= 7 ? "rgba(201,184,122,0.22)" : "rgba(126,184,164,0.22)"}`, padding: "3px 10px", borderRadius: 999 }}>
+                {days < 0 ? `${Math.abs(days)}d overdue` : days === 0 ? "Today" : `${days}d to handover`}
+              </span>
+            </div>
+          )}
+        </div>
+        {c.status === "COMPLETED" && (
+          <div style={{ background: "rgba(126,184,164,0.08)", border: "1.5px solid rgba(126,184,164,0.22)", borderRadius: 10, padding: "10px 14px", marginBottom: 14, fontSize: 13, color: "#2a6049", display: "flex", alignItems: "center", gap: 8 }}>
+            🎉 Property purchase completed successfully.
+          </div>
+        )}
+        <div style={{ display: "flex", gap: 8, paddingTop: 12, borderTop: "1.5px solid #f0ece3" }}>
+          <button onClick={() => onDetail(c)} className="msc-btn" style={{ flex: 1, padding: "8px 14px", borderRadius: 10, background: "#f0ece3", color: "#4a4438", border: "1.5px solid #e8e2d6", fontSize: 12.5, fontWeight: 500, cursor: "pointer", fontFamily: "'DM Sans',sans-serif", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>📄 Details</button>
+          <button onClick={() => onPayments(c)} className="msc-btn" style={{ flex: 1, padding: "8px 14px", borderRadius: 10, background: "#1a1714", color: "#f5f0e8", border: "none", fontSize: 12.5, fontWeight: 600, cursor: "pointer", fontFamily: "'DM Sans',sans-serif", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>💳 Payments</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+ 
+// ─── Contract Detail Modal ─────────────────────────────────────────────────────
+export function ContractDetailModal({ contract: c, onClose, onViewPayments }) {
+  const st   = getContractStatus(c.status);
+  const days = daysUntil(c.handover_date);
+ 
+  useEffect(() => {
+    const h = e => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", h);
+    document.body.style.overflow = "hidden";
+    return () => { window.removeEventListener("keydown", h); document.body.style.overflow = ""; };
+  }, [onClose]);
+ 
+  return (
+    <div onClick={e => e.target === e.currentTarget && onClose()} style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(8,6,4,0.84)", backdropFilter: "blur(14px)", display: "flex", alignItems: "center", justifyContent: "center", padding: 20, fontFamily: "'DM Sans',sans-serif" }}>
+      <div style={{ width: "100%", maxWidth: 560, background: "#faf7f2", borderRadius: 18, boxShadow: "0 44px 100px rgba(0,0,0,0.55)", maxHeight: "90vh", overflowY: "auto", animation: "msc-scale-in 0.24s ease" }}>
+ 
+        <div style={{ background: "linear-gradient(160deg,#141210 0%,#1e1a14 45%,#241e16 100%)", padding: "20px 24px 18px", borderRadius: "18px 18px 0 0", position: "relative" }}>
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: 2, background: "linear-gradient(90deg,transparent,#c9b87a 30%,#c9b87a 70%,transparent)", borderRadius: "18px 18px 0 0" }} />
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
+            <p style={{ fontSize: 10, fontWeight: 600, color: "#c9b87a", textTransform: "uppercase", letterSpacing: "1.2px", margin: 0 }}>Sale Contract</p>
+            <button onClick={onClose} style={{ background: "rgba(245,240,232,0.08)", border: "1px solid rgba(245,240,232,0.14)", borderRadius: 8, width: 30, height: 30, cursor: "pointer", color: "rgba(245,240,232,0.65)", fontSize: 16, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>×</button>
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12 }}>
+            <h2 style={{ fontFamily: "'Cormorant Garamond',Georgia,serif", fontSize: 22, fontWeight: 700, color: "#f5f0e8", margin: 0 }}>Contract #{c.id}</h2>
+            <span style={{ background: st.bg, color: st.color, border: `1px solid ${st.border}`, padding: "5px 14px", borderRadius: 999, fontSize: 11, fontWeight: 700, flexShrink: 0 }}>{st.icon} {st.label}</span>
+          </div>
+        </div>
+ 
+        <div style={{ padding: "22px 24px" }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 20 }}>
+            {[
+              { label: "Sale Price",    value: fmtMoney(c.sale_price, c.currency), accent: true },
+              { label: "Property",      value: `#${c.property_id}` },
+              { label: "Contract Date", value: fmtDate(c.contract_date) },
+              { label: "Handover Date", value: fmtDate(c.handover_date) },
+            ].map(({ label, value, accent }) => (
+              <div key={label} style={{ background: accent ? "rgba(201,184,122,0.07)" : "#fff", border: `1.5px solid ${accent ? "rgba(201,184,122,0.22)" : "#e8e2d6"}`, borderRadius: 12, padding: "13px 16px" }}>
+                <p style={{ fontSize: 9.5, fontWeight: 600, color: "#b0a890", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 5 }}>{label}</p>
+                <p style={{ fontSize: 17, fontWeight: 700, color: accent ? "#c9b87a" : "#1a1714", margin: 0, fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{value}</p>
+              </div>
+            ))}
+          </div>
+ 
+          {days !== null && c.status !== "COMPLETED" && c.status !== "CANCELLED" && (
+            <div style={{ background: days < 0 ? "rgba(212,133,90,0.08)" : days <= 7 ? "rgba(201,184,122,0.08)" : "rgba(126,184,164,0.08)", border: `1.5px solid ${days < 0 ? "rgba(212,133,90,0.25)" : days <= 7 ? "rgba(201,184,122,0.25)" : "rgba(126,184,164,0.25)"}`, borderRadius: 12, padding: "12px 16px", marginBottom: 16, fontSize: 13, color: days < 0 ? "#d4855a" : days <= 7 ? "#c9b87a" : "#2a6049", display: "flex", alignItems: "center", gap: 8 }}>
+              {days < 0 ? "⚠️" : days <= 7 ? "🕐" : "📅"}
+              {days < 0 ? `Handover was ${Math.abs(days)} day${Math.abs(days) !== 1 ? "s" : ""} ago` : days === 0 ? "Handover is today!" : `Handover in ${days} day${days !== 1 ? "s" : ""}`}
+            </div>
+          )}
+          {c.status === "COMPLETED" && (
+            <div style={{ background: "rgba(126,184,164,0.08)", border: "1.5px solid rgba(126,184,164,0.22)", borderRadius: 12, padding: "12px 16px", marginBottom: 16, fontSize: 13, color: "#2a6049", display: "flex", alignItems: "center", gap: 8 }}>
+              🎉 Congratulations! This property purchase has been completed.
+            </div>
+          )}
+          {c.contract_file_url && (
+            <div style={{ marginBottom: 16 }}>
+              <a href={c.contract_file_url} target="_blank" rel="noreferrer" style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px", background: "#fff", border: "1.5px solid #e8e2d6", borderRadius: 10, color: "#1a1714", textDecoration: "none", fontSize: 13 }}>
+                📎 <span>View Contract Document</span>
+                <span style={{ marginLeft: "auto", fontSize: 11, color: "#9a8c6e" }}>Open ↗</span>
+              </a>
+            </div>
+          )}
+          <div style={{ display: "flex", gap: 8, paddingTop: 16, borderTop: "1.5px solid #e8e2d6" }}>
+            <button onClick={() => onViewPayments(c)} className="msc-btn" style={{ flex: 1, padding: "10px 16px", borderRadius: 10, background: "linear-gradient(135deg,#c9b87a,#b0983e)", color: "#1a1714", border: "none", fontSize: 13.5, fontWeight: 700, cursor: "pointer", fontFamily: "'DM Sans',sans-serif", display: "flex", alignItems: "center", justifyContent: "center", gap: 7 }}>
+              💳 View Payments
+            </button>
+            <button onClick={onClose} className="msc-btn" style={{ padding: "10px 18px", borderRadius: 10, border: "1.5px solid #e4ddd0", background: "transparent", color: "#6b6248", fontWeight: 500, fontSize: 13, cursor: "pointer", fontFamily: "'DM Sans',sans-serif" }}>
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+ 
+// ─── Payments Quick Modal ──────────────────────────────────────────────────────
+export function PaymentsQuickModal({ contract: c, onClose, notify }) {
+  const [payments, setPayments] = useState([]);
+  const [summary,  setSummary]  = useState(null);
+  const [loading,  setLoading]  = useState(true);
+ 
+  useEffect(() => {
+    const h = e => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", h);
+    document.body.style.overflow = "hidden";
+    return () => { window.removeEventListener("keydown", h); document.body.style.overflow = ""; };
+  }, [onClose]);
+ 
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const [listRes, sumRes] = await Promise.all([
+          api.get(`/api/sales/payments/contract/${c.id}`),
+          api.get(`/api/sales/payments/contract/${c.id}/summary`),
+        ]);
+        setPayments(listRes.data || []);
+        setSummary(sumRes.data);
+      } catch { notify("Failed to load payments", "error"); }
+      finally { setLoading(false); }
+    })();
+  }, [c.id, notify]);
+ 
+  return (
+    <div onClick={e => e.target === e.currentTarget && onClose()} style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(8,6,4,0.84)", backdropFilter: "blur(14px)", display: "flex", alignItems: "center", justifyContent: "center", padding: 20, fontFamily: "'DM Sans',sans-serif" }}>
+      <div style={{ width: "100%", maxWidth: 640, background: "#faf7f2", borderRadius: 18, boxShadow: "0 44px 100px rgba(0,0,0,0.55)", maxHeight: "90vh", overflowY: "auto", animation: "msc-scale-in 0.24s ease" }}>
+        <div style={{ background: "linear-gradient(160deg,#141210 0%,#1e1a14 100%)", padding: "20px 24px 18px", borderRadius: "18px 18px 0 0", position: "relative" }}>
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: 2, background: "linear-gradient(90deg,transparent,#c9b87a 30%,#c9b87a 70%,transparent)", borderRadius: "18px 18px 0 0" }} />
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+            <p style={{ fontSize: 10, fontWeight: 600, color: "#c9b87a", textTransform: "uppercase", letterSpacing: "1.2px", margin: 0 }}>Payments</p>
+            <button onClick={onClose} style={{ background: "rgba(245,240,232,0.08)", border: "1px solid rgba(245,240,232,0.14)", borderRadius: 8, width: 30, height: 30, cursor: "pointer", color: "rgba(245,240,232,0.65)", fontSize: 16, display: "flex", alignItems: "center", justifyContent: "center" }}>×</button>
+          </div>
+          <h2 style={{ fontFamily: "'Cormorant Garamond',Georgia,serif", fontSize: 19, fontWeight: 700, color: "#f5f0e8", margin: "0 0 12px" }}>
+            Contract #{c.id} · {fmtMoney(c.sale_price, c.currency)}
+          </h2>
+          {summary && (
+            <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+              {[{ label: "Total", value: summary.total_payments, color: "#c9b87a" }, { label: "Paid", value: fmtMoney(summary.total_paid), color: "#7eb8a4" }].map(s => (
+                <div key={s.label}>
+                  <span style={{ fontSize: 9.5, color: "rgba(245,240,232,0.35)", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.8px" }}>{s.label} </span>
+                  <span style={{ fontSize: 16, fontWeight: 700, color: s.color, fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{s.value}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ padding: "18px 24px" }}>
+          {loading && <div style={{ textAlign: "center", padding: 36, color: "#9a8c6e" }}><div style={{ width: 24, height: 24, margin: "0 auto 12px", border: "2px solid #e8e2d6", borderTop: "2px solid #c9b87a", borderRadius: "50%", animation: "msc-spin .8s linear infinite" }} /><p style={{ fontSize: 13 }}>Loading payments…</p></div>}
+          {!loading && payments.length === 0 && <div style={{ textAlign: "center", padding: "32px 16px", color: "#b0a890" }}><div style={{ fontSize: 36, marginBottom: 10 }}>💳</div><p style={{ fontSize: 14 }}>No payments found.</p></div>}
+          {!loading && payments.length > 0 && (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {payments.map(p => {
+                const tc = getType(p.payment_type);
+                const sc = getPaymentStatus(p.status);
+                return (
+                  <div key={p.id} style={{ background: "#fff", border: "1.5px solid #e8e2d6", borderRadius: 11, padding: "13px 16px" }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                        <span style={{ background: tc.bg, color: tc.color, padding: "2px 9px", borderRadius: 999, fontSize: 10.5, fontWeight: 600 }}>{p.payment_type}</span>
+                        <span style={{ fontSize: 16, fontWeight: 700, color: "#1a1714", fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{fmtMoney(p.amount, p.currency)}</span>
+                      </div>
+                      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                        {p.paid_date && <span style={{ fontSize: 12, color: "#9a8c6e" }}>{fmtDate(p.paid_date)}</span>}
+                        <span style={{ background: sc.bg, color: sc.color, padding: "2px 10px", borderRadius: 999, fontSize: 10.5, fontWeight: 600 }}>{p.status}</span>
+                      </div>
+                    </div>
+                    <p style={{ fontSize: 12, color: "#9a8c6e", margin: "6px 0 0" }}>
+                      → {p.recipient_name ? <><strong style={{ color: "#6b6248" }}>{p.recipient_name}</strong> ({p.recipient_type})</> : <span style={{ color: "#7eb8a4", fontWeight: 600 }}>Company</span>}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+ 

--- a/src/components/client/salecontracts/PaymentComponents.jsx
+++ b/src/components/client/salecontracts/PaymentComponents.jsx
@@ -1,0 +1,61 @@
+import { fmtMoney, fmtDate, isOverdue, getType, getPaymentStatus } from "./saleConstants";
+ 
+// ─── Section Label ─────────────────────────────────────────────────────────────
+export function SectionLabel({ label, count, color, borderColor }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+      <span style={{ fontSize: 11, fontWeight: 700, color, textTransform: "uppercase", letterSpacing: "0.9px" }}>{label}</span>
+      <span style={{ background: `${color}20`, color, border: `1.5px solid ${borderColor || color + "40"}`, borderRadius: 999, padding: "2px 10px", fontSize: 11, fontWeight: 700 }}>{count}</span>
+      <div style={{ flex: 1, height: 1, background: `${color}25` }} />
+    </div>
+  );
+}
+ 
+// ─── Payment Row ───────────────────────────────────────────────────────────────
+export function PaymentRow({ payment: p, idx }) {
+  const sc  = getPaymentStatus(p.status);
+  const tc  = getType(p.payment_type);
+  const odd = isOverdue(p);
+ 
+  return (
+    <div style={{
+      background: odd ? "rgba(212,133,90,0.05)" : "#fff",
+      border: `1.5px solid ${odd ? "rgba(212,133,90,0.28)" : "#e8e2d6"}`,
+      borderRadius: 11, padding: "14px 18px",
+      animation: `msp-row-in 0.3s ease ${Math.min(idx * 0.04, 0.3)}s both`,
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10, flexWrap: "wrap", marginBottom: 8 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <span style={{ background: tc.bg, color: tc.color, border: `1.5px solid ${tc.border}`, padding: "3px 11px", borderRadius: 999, fontSize: 11, fontWeight: 700 }}>{tc.label}</span>
+          <span style={{ fontSize: 19, fontWeight: 700, color: "#1a1714", fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{fmtMoney(p.amount, p.currency)}</span>
+          {odd && <span style={{ fontSize: 11, color: "#d4855a", fontWeight: 700, background: "rgba(212,133,90,0.1)", border: "1px solid rgba(212,133,90,0.28)", padding: "2px 8px", borderRadius: 999 }}>⚠️ Overdue</span>}
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          {p.paid_date  && <span style={{ fontSize: 12, color: "#9a8c6e" }}>Paid {fmtDate(p.paid_date)}</span>}
+          {!p.paid_date && p.due_date && <span style={{ fontSize: 12, color: odd ? "#d4855a" : "#9a8c6e", fontWeight: odd ? 600 : 400 }}>Due {fmtDate(p.due_date)}</span>}
+          <span style={{ background: sc.bg, color: sc.color, border: `1.5px solid ${sc.border}`, padding: "3px 11px", borderRadius: 999, fontSize: 11, fontWeight: 700 }}>{sc.label}</span>
+        </div>
+      </div>
+      <div style={{ fontSize: 12.5, color: "#9a8c6e", display: "flex", alignItems: "center", gap: 5 }}>
+        <span style={{ color: "#c9b87a" }}>→</span>
+        {p.recipient_name
+          ? <><strong style={{ color: "#6b6248" }}>{p.recipient_name}</strong> <span style={{ background: "#f0ece3", color: "#9a8c6e", padding: "1px 7px", borderRadius: 999, fontSize: 10.5, fontWeight: 600 }}>{p.recipient_type}</span></>
+          : <span style={{ color: "#2a6049", fontWeight: 600, background: "rgba(126,184,164,0.1)", border: "1px solid rgba(126,184,164,0.22)", padding: "1px 8px", borderRadius: 999, fontSize: 11 }}>🏢 Company</span>
+        }
+        {p.transaction_ref && <span style={{ marginLeft: 8, background: "#f0ece3", color: "#9a8c6e", padding: "1px 8px", borderRadius: 999, fontSize: 10.5 }}>Ref: {p.transaction_ref}</span>}
+      </div>
+    </div>
+  );
+}
+ 
+// ─── Contract Tab button ───────────────────────────────────────────────────────
+export function ContractTab({ contract: c, selected, onSelect }) {
+  const dotColor = c.status === "COMPLETED" ? "#7eb8a4" : c.status === "CANCELLED" ? "#9a8c6e" : "#c9b87a";
+  return (
+    <button onClick={() => onSelect(c.id)} style={{ padding: "9px 16px", borderRadius: 10, background: selected ? "#1a1714" : "#fff", color: selected ? "#f5f0e8" : "#4a4438", border: `1.5px solid ${selected ? "#1a1714" : "#e8e2d6"}`, cursor: "pointer", fontFamily: "'DM Sans',sans-serif", fontSize: 12.5, fontWeight: selected ? 600 : 400, transition: "all 0.15s", whiteSpace: "nowrap", display: "flex", alignItems: "center", gap: 7 }}>
+      <span style={{ width: 7, height: 7, borderRadius: "50%", background: dotColor, display: "inline-block", flexShrink: 0 }} />
+      #{c.id} — {fmtMoney(c.sale_price, c.currency)}
+    </button>
+  );
+}
+ 

--- a/src/components/client/salecontracts/SaleContractsUI.jsx
+++ b/src/components/client/salecontracts/SaleContractsUI.jsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { PGB } from "./saleConstants";
+ 
+export function Toast({ msg, type = "success", onDone }) {
+  useEffect(() => { const t = setTimeout(onDone, 3200); return () => clearTimeout(t); }, [onDone]);
+  return (
+    <div style={{ position: "fixed", bottom: 26, right: 26, zIndex: 9999, background: "#1a1714", color: type === "error" ? "#f09090" : "#90c8a8", padding: "11px 18px", borderRadius: 12, fontSize: 13, boxShadow: "0 10px 36px rgba(0,0,0,0.32)", border: `1px solid ${type === "error" ? "rgba(240,128,128,0.15)" : "rgba(144,200,168,0.15)"}`, maxWidth: 320, fontFamily: "'DM Sans',sans-serif", animation: "msc-toast 0.2s ease", display: "flex", alignItems: "center", gap: 8 }}>
+      <span style={{ fontSize: 14 }}>{type === "error" ? "⚠️" : "✅"}</span>{msg}
+    </div>
+  );
+}
+ 
+export function Skeleton() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} style={{ background: "linear-gradient(90deg,#ede9df 25%,#e4ddd0 50%,#ede9df 75%)", backgroundSize: "800px 100%", borderRadius: 14, height: 160, animation: "msc-pulse 1.6s ease-in-out infinite" }} />
+      ))}
+    </div>
+  );
+}
+ 
+export function Pagination({ page, totalPages, onChange }) {
+  if (totalPages <= 1) return null;
+  const pages   = Array.from({ length: totalPages }, (_, i) => i);
+  const visible = pages.filter(p => p === 0 || p === totalPages - 1 || Math.abs(p - page) <= 1);
+  return (
+    <div style={{ display: "flex", justifyContent: "center", gap: 4, marginTop: 36, flexWrap: "wrap" }}>
+      <button disabled={page === 0} onClick={() => onChange(page - 1)} style={PGB(false, page === 0)}>‹</button>
+      {visible.map((p, i) => {
+        const gap = visible[i - 1] != null && p - visible[i - 1] > 1;
+        return (<span key={p} style={{ display: "flex", gap: 4 }}>{gap && <span style={{ padding: "7px 4px", color: "#b0a890", fontSize: 13 }}>…</span>}<button onClick={() => onChange(p)} style={PGB(p === page, false)}>{p + 1}</button></span>);
+      })}
+      <button disabled={page === totalPages - 1} onClick={() => onChange(page + 1)} style={PGB(false, page === totalPages - 1)}>›</button>
+    </div>
+  );
+}
+ 

--- a/src/components/client/salecontracts/saleConstants.js
+++ b/src/components/client/salecontracts/saleConstants.js
@@ -1,0 +1,85 @@
+export const CSS_CONTRACTS = `
+  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=DM+Sans:wght@300;400;500;600&display=swap');
+  .msc * { box-sizing: border-box; }
+  .msc { font-family: 'DM Sans', system-ui, sans-serif; background: #f2ede4; min-height: 100vh; }
+  .msc-card { transition: transform 0.22s cubic-bezier(0.25,0.46,0.45,0.94), box-shadow 0.22s ease; }
+  .msc-card:hover { transform: translateY(-4px); box-shadow: 0 20px 48px rgba(20,16,10,0.14) !important; }
+  .msc-btn { transition: all 0.15s ease; }
+  .msc-btn:hover:not(:disabled) { opacity: 0.86; transform: translateY(-1px); }
+  @keyframes msc-scale-in { from{opacity:0;transform:scale(0.95) translateY(10px)} to{opacity:1;transform:scale(1) translateY(0)} }
+  @keyframes msc-spin  { to{transform:rotate(360deg)} }
+  @keyframes msc-pulse { 0%,100%{opacity:.38} 50%{opacity:.82} }
+  @keyframes msc-toast { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
+  @keyframes msc-glow  { 0%,100%{opacity:0.07} 50%{opacity:0.14} }
+  @keyframes msc-card-in { from{opacity:0;transform:translateY(16px)} to{opacity:1;transform:translateY(0)} }
+`;
+ 
+export const CSS_PAYMENTS = `
+  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=DM+Sans:wght@300;400;500;600&display=swap');
+  .msp * { box-sizing: border-box; }
+  .msp { font-family: 'DM Sans', system-ui, sans-serif; background: #f2ede4; min-height: 100vh; }
+  .msp-card { background: #fff; border-radius: 14px; border: 1.5px solid #ece6da; box-shadow: 0 2px 16px rgba(20,16,10,0.07); }
+  .msp-btn { transition: all 0.15s ease; }
+  .msp-btn:hover:not(:disabled) { opacity: 0.86; transform: translateY(-1px); }
+  @keyframes msp-spin   { to{transform:rotate(360deg)} }
+  @keyframes msp-pulse  { 0%,100%{opacity:.38} 50%{opacity:.82} }
+  @keyframes msp-toast  { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
+  @keyframes msp-glow   { 0%,100%{opacity:0.07} 50%{opacity:0.14} }
+  @keyframes msp-row-in { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
+`;
+ 
+export const fmtMoney = (v, cur = "EUR") =>
+  v != null ? new Intl.NumberFormat("de-DE", { style: "currency", currency: cur, maximumFractionDigits: 0 }).format(Number(v)) : "—";
+ 
+export const fmtDate = d =>
+  d ? new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" }) : "—";
+ 
+export const daysUntil = d => {
+  if (!d) return null;
+  return Math.ceil((new Date(d) - new Date()) / 86400000);
+};
+ 
+export const isOverdue = p => {
+  if (!p.due_date || p.status !== "PENDING") return false;
+  return new Date(p.due_date) < new Date();
+};
+ 
+export const CONTRACT_STATUS_CFG = {
+  PENDING:           { bg: "rgba(201,184,122,0.10)", color: "#a8923e", border: "rgba(201,184,122,0.28)", label: "Pending",           icon: "⏳", strip: "#c9b87a" },
+  PENDING_SIGNATURE: { bg: "rgba(201,184,122,0.10)", color: "#a8923e", border: "rgba(201,184,122,0.28)", label: "Pending Signature", icon: "✍️", strip: "#c9b87a" },
+  ACTIVE:            { bg: "rgba(126,184,164,0.12)", color: "#2a6049", border: "rgba(126,184,164,0.28)", label: "Active",            icon: "✅", strip: "#7eb8a4" },
+  COMPLETED:         { bg: "rgba(126,184,164,0.12)", color: "#2a6049", border: "rgba(126,184,164,0.28)", label: "Completed",         icon: "🏆", strip: "#5aaa80" },
+  CANCELLED:         { bg: "rgba(160,153,126,0.10)", color: "#6b6248", border: "rgba(160,153,126,0.20)", label: "Cancelled",         icon: "🚫", strip: "#9a8c6e" },
+};
+export const getContractStatus = s => CONTRACT_STATUS_CFG[s] || { bg: "#f0ece3", color: "#6b6248", border: "#e0d8c8", label: s, icon: "📄", strip: "#b0a890" };
+ 
+export const PAYMENT_TYPE_COLORS = {
+  FULL:             { bg: "rgba(201,184,122,0.15)", color: "#7a6220",  border: "rgba(201,184,122,0.35)", label: "Full Payment"     },
+  DEPOSIT:          { bg: "rgba(126,184,164,0.15)", color: "#1e5040",  border: "rgba(126,184,164,0.35)", label: "Deposit"          },
+  INSTALLMENT:      { bg: "rgba(100,120,180,0.10)", color: "#3a4a8a",  border: "rgba(100,120,180,0.28)", label: "Installment"      },
+  COMMISSION:       { bg: "rgba(126,184,164,0.12)", color: "#2a6049",  border: "rgba(126,184,164,0.28)", label: "Commission"       },
+  AGENT_COMMISSION: { bg: "rgba(201,184,122,0.12)", color: "#8a6430",  border: "rgba(201,184,122,0.28)", label: "Agent Commission" },
+  CLIENT_BONUS:     { bg: "rgba(164,176,126,0.12)", color: "#4a6030",  border: "rgba(164,176,126,0.28)", label: "Client Bonus"     },
+};
+export const getType = t => PAYMENT_TYPE_COLORS[t] || { bg: "#f0ece3", color: "#6b6248", border: "#e0d8c8", label: t || "—" };
+ 
+export const PAYMENT_STATUS_CFG = {
+  PENDING:  { bg: "rgba(201,184,122,0.12)", color: "#8a7230", border: "rgba(201,184,122,0.35)", label: "Pending",  strip: "#c9b87a" },
+  PAID:     { bg: "rgba(126,184,164,0.14)", color: "#1e5040", border: "rgba(126,184,164,0.35)", label: "Paid",     strip: "#7eb8a4" },
+  FAILED:   { bg: "rgba(212,133,90,0.12)",  color: "#7a3010", border: "rgba(212,133,90,0.30)",  label: "Failed",   strip: "#d4855a" },
+  REFUNDED: { bg: "rgba(160,153,126,0.12)", color: "#5a5238", border: "rgba(160,153,126,0.28)", label: "Refunded", strip: "#9a8c6e" },
+};
+export const getPaymentStatus = s => PAYMENT_STATUS_CFG[s] || { bg: "#f0ece3", color: "#6b6248", border: "#e0d8c8", label: s, strip: "#b0a890" };
+ 
+// Shared hero dot config
+export const PGB = (active, disabled) => ({
+  padding: "7px 13px", borderRadius: 9,
+  border: `1.5px solid ${active ? "#1a1714" : "#e4ddd0"}`,
+  background: active ? "#1a1714" : "transparent",
+  color: active ? "#f5f0e8" : disabled ? "#d4ccbe" : "#6b6248",
+  cursor: disabled ? "not-allowed" : "pointer",
+  fontSize: 13, fontWeight: active ? 600 : 400,
+  fontFamily: "'DM Sans',sans-serif",
+  opacity: disabled ? 0.5 : 1, transition: "all 0.14s",
+});
+ 

--- a/src/pages/client/ClientLeads.jsx
+++ b/src/pages/client/ClientLeads.jsx
@@ -2,1073 +2,27 @@ import { useState, useEffect, useCallback, useContext } from "react";
 import MainLayout from "../../components/layout/Layout";
 import { AuthContext } from "../../context/AuthProvider";
 import api from "../../api/axios";
-
-// ─── Constants ────────────────────────────────────────────────────────────────
-const LEAD_TYPES     = ["SELL", "RENT", "VALUATION"];
-const LEAD_SOURCES   = ["WEBSITE", "PHONE", "EMAIL", "REFERRAL", "SOCIAL"];
-const PROPERTY_TYPES = ["APARTMENT", "HOUSE", "VILLA", "COMMERCIAL", "LAND", "OFFICE"];
-const CURRENCIES     = ["EUR", "USD", "ALL", "GBP", "CHF"];
-const PRICE_PERIODS  = ["MONTHLY", "YEARLY", "DAILY", "WEEKLY"];
-
-// Which fields are shown per property type
-const TYPE_FIELDS = {
-  APARTMENT: { floor: true,  total_floors: true,  bedrooms: true,  bathrooms: true,  year_built: true,  area_sqm: true },
-  HOUSE:     { floor: false, total_floors: true, bedrooms: true,  bathrooms: true,  year_built: true,  area_sqm: true },
-  VILLA:     { floor: false, total_floors: true, bedrooms: true,  bathrooms: true,  year_built: true,  area_sqm: true },
-  COMMERCIAL:{ floor: true,  total_floors: true,  bedrooms: false, bathrooms: false, year_built: true,  area_sqm: true },
-  LAND:      { floor: false, total_floors: false, bedrooms: false, bathrooms: false, year_built: false, area_sqm: true },
-  OFFICE:    { floor: true,  total_floors: true,  bedrooms: false, bathrooms: true,  year_built: true,  area_sqm: true },
-};
-
-const TYPE_LABEL = {
-  SELL:      "Sell a property",
-  RENT:      "Rent out a property",
-  VALUATION: "Property valuation",
-};
-
-const SOURCE_LABEL = {
-  WEBSITE:  "Website",
-  PHONE:    "Phone",
-  EMAIL:    "Email",
-  REFERRAL: "Referral",
-  SOCIAL:   "Social Media",
-};
-
-const fmtDate     = d => d ? new Date(d).toLocaleDateString("en-GB", { day:"2-digit", month:"short", year:"numeric" }) : "—";
-const fmtDateTime = d => d ? new Date(d).toLocaleString("en-GB", { day:"2-digit", month:"short", year:"numeric", hour:"2-digit", minute:"2-digit" }) : "—";
-
-// ─── SVG Icons ────────────────────────────────────────────────────────────────
-const Ico = (d, w=15, sw=1.8) => (
-  <svg width={w} height={w} viewBox="0 0 24 24" fill="none" stroke="currentColor"
-    strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round">{d}</svg>
-);
-const PlusIcon       = () => Ico(<><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></>, 14, 2.2);
-const HomeIcon       = () => Ico(<><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></>, 14);
-const TagIcon        = () => Ico(<><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></>, 14);
-const KeyIcon        = () => Ico(<><circle cx="7.5" cy="15.5" r="5.5"/><path d="M21 2 10.58 12.42M13 7l3 3M18 2l3 3-6 6-3-3"/></>, 14);
-const ChartIcon      = () => Ico(<><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></>, 14);
-const CalendarIcon   = () => Ico(<><rect width="18" height="18" x="3" y="4" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></>, 13);
-const UserIcon       = () => Ico(<><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></>, 13);
-const PinIcon        = () => Ico(<><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></>, 12);
-const AreaIcon       = () => Ico(<><path d="M3 3h7v7H3z"/><path d="M14 3h7v7h-7z"/><path d="M14 14h7v7h-7z"/><path d="M3 14h7v7H3z"/></>, 13);
-const BedIcon        = () => Ico(<><path d="M2 4v16"/><path d="M22 8H2"/><path d="M22 20V8l-4-4H6L2 8"/><path d="M6 8v4"/><path d="M18 8v4"/></>, 13);
-const ArrowRightIcon = () => Ico(<><path d="m9 18 6-6-6-6"/></>, 13, 2.2);
-const ClockIcon      = () => Ico(<><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></>, 13);
-
-const TYPE_ICON = {
-  SELL:      <TagIcon />,
-  RENT:      <KeyIcon />,
-  VALUATION: <ChartIcon />,
-};
-
-// ─── Global CSS ───────────────────────────────────────────────────────────────
-const CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=DM+Sans:wght@300;400;500;600&display=swap');
-  .cl * { box-sizing: border-box; }
-  .cl { font-family: 'DM Sans', system-ui, sans-serif; background: #f2ede4; min-height: 100vh; }
-  .cl-card { transition: transform 0.25s cubic-bezier(0.25,0.46,0.45,0.94), box-shadow 0.25s ease; }
-  .cl-card:hover { transform: translateY(-4px); box-shadow: 0 20px 48px rgba(20,16,10,0.13) !important; }
-  .cl-btn { transition: all 0.17s ease; }
-  .cl-btn:hover:not(:disabled) { opacity: 0.86; transform: translateY(-1px); }
-  .cl-in:focus { border-color: #8a7d5e !important; box-shadow: 0 0 0 3px rgba(138,125,94,0.13) !important; outline: none; }
-  @keyframes cl-fade-up  { from{opacity:0;transform:translateY(18px)} to{opacity:1;transform:translateY(0)} }
-  @keyframes cl-scale-in { from{opacity:0;transform:scale(0.95) translateY(12px)} to{opacity:1;transform:scale(1) translateY(0)} }
-  @keyframes cl-spin     { to{transform:rotate(360deg)} }
-  @keyframes cl-toast    { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
-  @keyframes cl-card-in  { from{opacity:0;transform:translateY(20px)} to{opacity:1;transform:translateY(0)} }
-  @keyframes cl-shimmer  { 0%{background-position:-800px 0} 100%{background-position:800px 0} }
-`;
-
-// ─── Toast ────────────────────────────────────────────────────────────────────
-function Toast({ msg, type = "success", onDone }) {
-  useEffect(() => { const t = setTimeout(onDone, 3000); return () => clearTimeout(t); }, [onDone]);
-  return (
-    <div style={{
-      position:"fixed", bottom:26, right:26, zIndex:9999,
-      background:"#1a1714", color:type==="error"?"#e08080":"#80c0a0",
-      padding:"11px 18px", borderRadius:12, fontSize:13,
-      boxShadow:"0 10px 36px rgba(0,0,0,0.32)",
-      border:`1px solid ${type==="error"?"rgba(224,128,128,0.15)":"rgba(128,192,160,0.15)"}`,
-      maxWidth:320, fontFamily:"'DM Sans',sans-serif",
-      animation:"cl-toast 0.2s ease", display:"flex", alignItems:"center", gap:8,
-    }}>
-      <span style={{ opacity:0.5, fontSize:11 }}>{type==="error" ? "✕" : "✓"}</span>
-      {msg}
-    </div>
-  );
-}
-
-// ─── Skeleton ─────────────────────────────────────────────────────────────────
-function Skeleton() {
-  return (
-    <div style={{ display:"flex", flexDirection:"column", gap:14 }}>
-      {Array.from({ length:3 }).map((_,i) => (
-        <div key={i} style={{
-          background:"linear-gradient(90deg,#ede9df 25%,#e4ddd0 50%,#ede9df 75%)",
-          backgroundSize:"800px 100%", borderRadius:14, height:118,
-          animation:"cl-shimmer 1.5s ease-in-out infinite",
-        }}/>
-      ))}
-    </div>
-  );
-}
-
-// ─── Shared field styles ──────────────────────────────────────────────────────
-const INP_S = {
-  width:"100%", padding:"10px 13px", border:"1.5px solid #e4ddd0",
-  borderRadius:10, fontSize:13.5, color:"#1a1714",
-  background:"#fff", fontFamily:"'DM Sans',sans-serif",
-  boxSizing:"border-box", outline:"none", transition:"border-color 0.2s",
-};
-const SEL_S = { ...INP_S, cursor:"pointer" };
-const LBL = {
-  display:"block", fontSize:10.5, fontWeight:600, color:"#9a8c6e",
-  textTransform:"uppercase", letterSpacing:"0.7px", marginBottom:6,
-  fontFamily:"'DM Sans',sans-serif",
-};
-
-function Field({ label, children, required, hint }) {
-  return (
-    <div style={{ marginBottom:13 }}>
-      <label style={LBL}>
-        {label}{required && <span style={{ color:"#c0392b", marginLeft:2 }}>*</span>}
-      </label>
-      {children}
-      {hint && <p style={{ fontSize:11.5, color:"#b0a890", marginTop:4 }}>{hint}</p>}
-    </div>
-  );
-}
-
-// ─── Modal wrapper ────────────────────────────────────────────────────────────
-function ModalWrap({ children, onClose, maxW = 620 }) {
-  useEffect(() => {
-    const h = e => e.key === "Escape" && onClose();
-    window.addEventListener("keydown", h);
-    return () => window.removeEventListener("keydown", h);
-  }, [onClose]);
-  useEffect(() => {
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, []);
-  return (
-    <div onClick={e => e.target === e.currentTarget && onClose()}
-      style={{
-        position:"fixed", inset:0, zIndex:1000,
-        background:"rgba(8,6,4,0.84)", backdropFilter:"blur(14px)",
-        display:"flex", alignItems:"center", justifyContent:"center",
-        padding:20, fontFamily:"'DM Sans',sans-serif",
-      }}>
-      <div style={{
-        width:"100%", maxWidth:maxW, background:"#faf7f2", borderRadius:18,
-        boxShadow:"0 44px 100px rgba(0,0,0,0.55)", maxHeight:"92vh",
-        overflowY:"auto", animation:"cl-scale-in 0.26s ease",
-      }}>
-        {children}
-      </div>
-    </div>
-  );
-}
-
-function MH({ title, sub, onClose }) {
-  return (
-    <div style={{
-      background:"linear-gradient(135deg,#141210 0%,#1e1a14 45%,#241e16 100%)",
-      padding:"20px 26px", borderRadius:"18px 18px 0 0",
-      display:"flex", alignItems:"center", justifyContent:"space-between",
-      borderBottom:"1px solid rgba(201,184,122,0.14)",
-      position:"relative", overflow:"hidden",
-    }}>
-      <div style={{
-        position:"absolute", top:0, left:0, right:0, height:"2px",
-        background:"linear-gradient(90deg,transparent,#c9b87a 30%,#c9b87a 70%,transparent)",
-      }}/>
-      <div>
-        <p style={{
-          fontFamily:"'Cormorant Garamond',Georgia,serif", fontWeight:700,
-          fontSize:19, margin:"0 0 2px", color:"#f5f0e8", letterSpacing:"-0.2px",
-        }}>{title}</p>
-        {sub && <p style={{ fontSize:12, color:"rgba(245,240,232,0.38)", margin:0 }}>{sub}</p>}
-      </div>
-      <button onClick={onClose} style={{
-        background:"rgba(245,240,232,0.07)", backdropFilter:"blur(8px)",
-        border:"1px solid rgba(245,240,232,0.12)", borderRadius:9,
-        width:32, height:32, cursor:"pointer", display:"flex",
-        alignItems:"center", justifyContent:"center",
-        color:"rgba(245,240,232,0.55)", fontSize:16,
-      }}>×</button>
-    </div>
-  );
-}
-
-// ─── Property Fields ──────────────────────────────────────────────────────────
-function PropertyFields({ form, setForm }) {
-  const set = (k, v) => setForm(p => ({
-    ...p,
-    property_data: { ...p.property_data, [k]: v },
-  }));
-
-  const pd     = form.property_data || {};
-  const isRent = form.type === "RENT";
-  const fields = TYPE_FIELDS[pd.type || "APARTMENT"] || TYPE_FIELDS.APARTMENT;
-
-  const accent = isRent ? "#7eb8a4" : "#c9b87a";
-  const bg     = isRent ? "rgba(126,184,164,0.06)" : "rgba(201,184,122,0.06)";
-  const border = isRent ? "rgba(126,184,164,0.18)" : "rgba(201,184,122,0.18)";
-
-  // ── Auto-calculation ──────────────────────────────────────────────────────
-  const handlePrice = val => {
-    set("price", val);
-    if (val && pd.area_sqm && Number(pd.area_sqm) > 0)
-      set("price_per_sqm", (Number(val) / Number(pd.area_sqm)).toFixed(2));
-  };
-
-  const handleAreaSqm = val => {
-    set("area_sqm", val);
-    if (val && pd.price && Number(val) > 0)
-      set("price_per_sqm", (Number(pd.price) / Number(val)).toFixed(2));
-    else if (val && pd.price_per_sqm && Number(val) > 0)
-      set("price", (Number(pd.price_per_sqm) * Number(val)).toFixed(2));
-  };
-
-  const handlePricePerSqm = val => {
-    set("price_per_sqm", val);
-    if (val && pd.area_sqm && Number(pd.area_sqm) > 0)
-      set("price", (Number(val) * Number(pd.area_sqm)).toFixed(2));
-  };
-
-  // When property type changes — clear irrelevant fields
-  const handleTypeChange = val => {
-    const nf = TYPE_FIELDS[val] || TYPE_FIELDS.APARTMENT;
-    set("type", val);
-    if (!nf.floor)        set("floor", "");
-    if (!nf.total_floors) set("total_floors", "");
-    if (!nf.bedrooms)     set("bedrooms", "");
-    if (!nf.bathrooms)    set("bathrooms", "");
-    if (!nf.year_built)   set("year_built", "");
-  };
-
-  // Count visible columns for grid
-  const roomCols   = [true, fields.bedrooms, fields.bathrooms].filter(Boolean).length;
-  const floorCols  = [fields.floor, fields.total_floors, fields.year_built].filter(Boolean).length;
-  const priceCols  = isRent ? 4 : 3;
-
-  return (
-    <div style={{
-      marginTop:8, padding:"16px 14px", background:bg,
-      borderRadius:12, border:`1.5px solid ${border}`, marginBottom:14,
-    }}>
-      <p style={{
-        fontSize:10, fontWeight:700, color:accent,
-        textTransform:"uppercase", letterSpacing:"1px",
-        marginBottom:14, display:"flex", alignItems:"center", gap:6,
-      }}>
-        <HomeIcon /> Property details
-        <span style={{ fontSize:10, fontWeight:400, color:"#b0a890", textTransform:"none", letterSpacing:0 }}>
-          (agent will register in the system)
-        </span>
-      </p>
-
-      {/* Title + Type */}
-      <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:12 }}>
-        <Field label="Property title" required>
-          <input className="cl-in" style={INP_S}
-            value={pd.title || ""}
-            onChange={e => set("title", e.target.value)}
-            placeholder="e.g. 2+1 Apartment Tirana" />
-        </Field>
-        <Field label="Property type" required>
-          <select className="cl-in" style={SEL_S}
-            value={pd.type || "APARTMENT"}
-            onChange={e => handleTypeChange(e.target.value)}>
-            {PROPERTY_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
-          </select>
-        </Field>
-      </div>
-
-      {/* Price block */}
-      <div style={{
-        background:"#fff", border:"1px solid #e8e2d6",
-        borderRadius:10, padding:"12px 14px", marginBottom:12,
-      }}>
-        <p style={{
-          fontSize:10, fontWeight:700, color:"#9a8c6e",
-          textTransform:"uppercase", letterSpacing:"0.7px", margin:"0 0 10px",
-        }}>
-          💡 Fill any two price fields — the third calculates automatically
-        </p>
-
-        <div style={{ display:"grid", gridTemplateColumns:`repeat(${priceCols}, 1fr)`, gap:12 }}>
-          <Field label={isRent ? "Rent price" : "Asking price"} required>
-            <input className="cl-in" style={INP_S}
-              type="number" min="0"
-              value={pd.price || ""}
-              onChange={e => handlePrice(e.target.value)}
-              placeholder={isRent ? "500" : "120000"} />
-          </Field>
-
-          <Field label="Price per m²">
-            <input className="cl-in" style={INP_S}
-              type="number" min="0"
-              value={pd.price_per_sqm || ""}
-              onChange={e => handlePricePerSqm(e.target.value)}
-              placeholder="1200" />
-          </Field>
-
-          <Field label="Currency">
-            <select className="cl-in" style={SEL_S}
-              value={pd.currency || "EUR"}
-              onChange={e => set("currency", e.target.value)}>
-              {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
-            </select>
-          </Field>
-
-          {isRent && (
-            <Field label="Period">
-              <select className="cl-in" style={SEL_S}
-                value={pd.price_period || "MONTHLY"}
-                onChange={e => set("price_period", e.target.value)}>
-                {PRICE_PERIODS.map(p => <option key={p} value={p}>{p}</option>)}
-              </select>
-            </Field>
-          )}
-        </div>
-
-        {/* Auto-calc confirmation */}
-        {pd.price && pd.area_sqm && pd.price_per_sqm && (
-          <div style={{
-            marginTop:8, padding:"6px 10px",
-            background:"#f0fdf4", borderRadius:7,
-            border:"1px solid #a7f3d0",
-            fontSize:12, color:"#047857",
-            display:"flex", gap:16, flexWrap:"wrap",
-          }}>
-            <span>Total: <strong>€{Number(pd.price).toLocaleString("de-DE")}</strong></span>
-            <span>Per m²: <strong>€{Number(pd.price_per_sqm).toLocaleString("de-DE")}</strong></span>
-            <span>Area: <strong>{pd.area_sqm} m²</strong></span>
-          </div>
-        )}
-      </div>
-
-      {/* Area + Bedrooms + Bathrooms */}
-      <div style={{ display:"grid", gridTemplateColumns:`repeat(${roomCols}, 1fr)`, gap:12 }}>
-        <Field label="Area (m²)">
-          <input className="cl-in" style={INP_S}
-            type="number" min="0"
-            value={pd.area_sqm || ""}
-            onChange={e => handleAreaSqm(e.target.value)}
-            placeholder="85" />
-        </Field>
-
-        {fields.bedrooms && (
-          <Field label="Bedrooms">
-            <input className="cl-in" style={INP_S}
-              type="number" min="0"
-              value={pd.bedrooms || ""}
-              onChange={e => set("bedrooms", e.target.value)}
-              placeholder="2" />
-          </Field>
-        )}
-
-        {fields.bathrooms && (
-          <Field label="Bathrooms">
-            <input className="cl-in" style={INP_S}
-              type="number" min="0"
-              value={pd.bathrooms || ""}
-              onChange={e => set("bathrooms", e.target.value)}
-              placeholder="1" />
-          </Field>
-        )}
-      </div>
-
-      {/* Floor + Total floors + Year built */}
-      {floorCols > 0 && (
-        <div style={{ display:"grid", gridTemplateColumns:`repeat(${floorCols}, 1fr)`, gap:12 }}>
-          {fields.floor && (
-            <Field label="Floor">
-              <input className="cl-in" style={INP_S}
-                type="number"
-                value={pd.floor || ""}
-                onChange={e => set("floor", e.target.value)}
-                placeholder="3" />
-            </Field>
-          )}
-          {fields.total_floors && (
-            <Field label="Total floors">
-              <input className="cl-in" style={INP_S}
-                type="number" min="1"
-                value={pd.total_floors || ""}
-                onChange={e => set("total_floors", e.target.value)}
-                placeholder="8" />
-            </Field>
-          )}
-          {fields.year_built && (
-            <Field label="Year built">
-              <input className="cl-in" style={INP_S}
-                type="number"
-                min="1900" max={new Date().getFullYear()}
-                value={pd.year_built || ""}
-                onChange={e => set("year_built", e.target.value)}
-                placeholder="2015" />
-            </Field>
-          )}
-        </div>
-      )}
-
-      {/* City + Street */}
-      <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:12 }}>
-        <Field label="City" required>
-          <input className="cl-in" style={INP_S}
-            value={pd.city || ""}
-            onChange={e => set("city", e.target.value)}
-            placeholder="Tirana" />
-        </Field>
-        <Field label="Street / Area">
-          <input className="cl-in" style={INP_S}
-            value={pd.street || ""}
-            onChange={e => set("street", e.target.value)}
-            placeholder="Rr. e Durrësit" />
-        </Field>
-      </div>
-
-      {/* Description */}
-      <Field label="Description" hint="Condition, features, included appliances, etc.">
-        <textarea className="cl-in"
-          value={pd.description || ""}
-          onChange={e => set("description", e.target.value)}
-          rows={2}
-          placeholder="Newly renovated, equipped kitchen, parking..."
-          style={{ ...INP_S, resize:"vertical" }} />
-      </Field>
-
-
-    </div>
-  );
-}
-
-// ─── Create Lead Modal ────────────────────────────────────────────────────────
-function CreateLeadModal({ onClose, onSuccess, notify }) {
-  const EMPTY_PD = {
-    title:"", type:"APARTMENT", area_sqm:"", bedrooms:"",
-    bathrooms:"", price:"", price_per_sqm:"", currency:"EUR",
-    city:"", street:"", year_built:"", floor:"",
-    total_floors:"", description:"", price_period:"MONTHLY",
-  };
-
-  const [form, setForm] = useState({
-    type:           "SELL",
-    message:        "",
-    preferred_date: "",
-    source:         "WEBSITE",
-    property_data:  { ...EMPTY_PD },
-  });
-  const [saving, setSaving] = useState(false);
-  const set = (k, v) => setForm(p => ({ ...p, [k]: v }));
-
-  // VALUATION has no property data
-  const handleTypeChange = t => {
-    setForm(p => ({
-      ...p,
-      type:          t,
-      property_data: t === "VALUATION" ? null : (p.property_data || { ...EMPTY_PD }),
-    }));
-  };
-
-  // Build message string with property data embedded
-  const buildMessage = () => {
-    const parts = [];
-    if (form.message?.trim()) parts.push(form.message.trim());
-
-    const pd = form.property_data;
-    if (pd && form.type !== "VALUATION") {
-      parts.push("\n--- Property Details ---");
-      if (pd.title)         parts.push(`Title: ${pd.title}`);
-      if (pd.type)          parts.push(`Type: ${pd.type}`);
-      if (pd.city)          parts.push(`City: ${pd.city}`);
-      if (pd.street)        parts.push(`Address: ${pd.street}`);
-      if (pd.area_sqm)      parts.push(`Area: ${pd.area_sqm} m²`);
-      if (pd.bedrooms)      parts.push(`Bedrooms: ${pd.bedrooms}`);
-      if (pd.bathrooms)     parts.push(`Bathrooms: ${pd.bathrooms}`);
-      if (pd.floor)         parts.push(`Floor: ${pd.floor}`);
-      if (pd.total_floors)  parts.push(`Total floors: ${pd.total_floors}`);
-      if (pd.year_built)    parts.push(`Year built: ${pd.year_built}`);
-      if (pd.price)         parts.push(`Price: ${pd.price} ${pd.currency}`);
-      if (pd.price_per_sqm) parts.push(`Price per m²: ${pd.price_per_sqm} ${pd.currency}`);
-      if (pd.price_period && form.type === "RENT")
-                            parts.push(`Period: ${pd.price_period}`);
-      if (pd.description)   parts.push(`Notes: ${pd.description}`);
-      parts.push(`\n__PROPERTY_DATA__:${JSON.stringify(pd)}`);
-    }
-    return parts.join("\n").trim() || null;
-  };
-
-  const handleSubmit = async () => {
-    if (form.type !== "VALUATION") {
-      const pd = form.property_data;
-      if (!pd?.title?.trim()) { notify("Property title is required", "error"); return; }
-      if (!pd?.city?.trim())  { notify("City is required", "error"); return; }
-      if (!pd?.price)         { notify("Price is required", "error"); return; }
-    } else {
-      if (!form.message?.trim()) {
-        notify("Please describe the property you want valued", "error"); return;
-      }
-    }
-
-    setSaving(true);
-    try {
-      await api.post("/api/leads", {
-        type:           form.type,
-        property_id:    null,
-        message:        buildMessage(),
-        budget:         null,
-        preferred_date: form.preferred_date || null,
-        source:         form.source,
-      });
-      onSuccess();
-    } catch (err) {
-      notify(err.response?.data?.message || "Error submitting request", "error");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const DATE_LABEL = {
-    SELL:      "Preferred listing date",
-    RENT:      "Date property is available from",
-    VALUATION: "Preferred valuation date",
-  };
-
-  const INFO = {
-    SELL: {
-      text:   "Have a property to sell? Fill in the details — your agent will register and list it.",
-      accent: "#c9b87a", bg: "rgba(201,184,122,0.07)", border: "rgba(201,184,122,0.18)",
-    },
-    RENT: {
-      text:   "Have a property to rent out? Provide the details — your agent will manage applications.",
-      accent: "#7eb8a4", bg: "rgba(126,184,164,0.07)", border: "rgba(126,184,164,0.18)",
-    },
-    VALUATION: {
-      text:   "Want a professional property valuation? Describe the property in your message.",
-      accent: "#a4b07e", bg: "rgba(164,176,126,0.07)", border: "rgba(164,176,126,0.18)",
-    },
-  };
-  const info = INFO[form.type] || INFO.SELL;
-
-  return (
-    <ModalWrap onClose={onClose} maxW={form.type !== "VALUATION" ? 700 : 520}>
-      <MH title="New Request" sub="Tell us what you need" onClose={onClose} />
-      <div style={{ padding:"22px 26px" }}>
-
-        {/* Request type */}
-        <Field label="Request type" required>
-          <div style={{ display:"flex", gap:10, flexWrap:"wrap" }}>
-            {LEAD_TYPES.map(t => (
-              <button key={t} onClick={() => handleTypeChange(t)}
-                style={{
-                  display:"flex", alignItems:"center", gap:7,
-                  padding:"10px 18px", borderRadius:10,
-                  border:`1.5px solid ${form.type===t ? "#8a7d5e" : "#e4ddd0"}`,
-                  background:form.type===t ? "#1a1714" : "transparent",
-                  color:form.type===t ? "#f5f0e8" : "#6b6248",
-                  cursor:"pointer", fontSize:13,
-                  fontWeight:form.type===t ? 600 : 400,
-                  fontFamily:"'DM Sans',sans-serif", transition:"all 0.15s",
-                }}>
-                <span style={{ opacity:form.type===t ? 1 : 0.5 }}>{TYPE_ICON[t]}</span>
-                {TYPE_LABEL[t]}
-              </button>
-            ))}
-          </div>
-        </Field>
-
-        {/* Info banner */}
-        <div style={{
-          background:info.bg, border:`1.5px solid ${info.border}`,
-          borderRadius:10, padding:"10px 14px", marginBottom:16,
-          fontSize:13, color:info.accent,
-          display:"flex", alignItems:"flex-start", gap:8,
-        }}>
-          <span style={{ opacity:0.7, marginTop:1, flexShrink:0 }}><HomeIcon /></span>
-          {info.text}
-        </div>
-
-        {/* Property fields — SELL and RENT only */}
-        {form.type !== "VALUATION" && (
-          <PropertyFields form={form} setForm={setForm} />
-        )}
-
-        {/* Preferred date */}
-        <Field label={DATE_LABEL[form.type] || "Preferred date"}>
-          <input className="cl-in" style={INP_S} type="date"
-            value={form.preferred_date}
-            onChange={e => set("preferred_date", e.target.value)}
-            min={new Date().toISOString().split("T")[0]} />
-        </Field>
-
-        {/* Source */}
-        <Field label="How did you find us?">
-          <select className="cl-in" style={SEL_S}
-            value={form.source}
-            onChange={e => set("source", e.target.value)}>
-            {LEAD_SOURCES.map(s => (
-              <option key={s} value={s}>{SOURCE_LABEL[s]}</option>
-            ))}
-          </select>
-        </Field>
-
-        {/* Message */}
-        <Field
-          label={form.type === "VALUATION" ? "Describe the property" : "Additional notes"}
-          required={form.type === "VALUATION"}>
-          <textarea className="cl-in"
-            value={form.message}
-            onChange={e => set("message", e.target.value)}
-            rows={3}
-            placeholder={
-              form.type === "VALUATION"
-                ? "Describe the property you want valued..."
-                : "Any other relevant details..."
-            }
-            style={{ ...INP_S, resize:"vertical" }} />
-        </Field>
-
-        {/* Actions */}
-        <div style={{
-          display:"flex", gap:9, justifyContent:"flex-end",
-          borderTop:"1px solid #e8e2d6", paddingTop:18, marginTop:4,
-        }}>
-          <button onClick={onClose} className="cl-btn"
-            style={{
-              padding:"10px 18px", borderRadius:10,
-              border:"1.5px solid #e4ddd0", background:"transparent",
-              color:"#6b6248", fontWeight:500, fontSize:13,
-              cursor:"pointer", fontFamily:"inherit",
-            }}>
-            Cancel
-          </button>
-          <button onClick={handleSubmit} disabled={saving} className="cl-btn"
-            style={{
-              padding:"10px 24px", borderRadius:10, border:"none",
-              background:saving ? "#b0a890" : "linear-gradient(135deg,#c9b87a 0%,#b0983e 100%)",
-              color:"#1a1714", fontSize:13, fontWeight:700,
-              cursor:saving ? "not-allowed" : "pointer",
-              fontFamily:"inherit", display:"flex", alignItems:"center", gap:7,
-            }}>
-            {saving
-              ? <><div style={{ width:14, height:14, border:"2px solid rgba(26,23,20,0.25)", borderTop:"2px solid #1a1714", borderRadius:"50%", animation:"cl-spin 0.7s linear infinite" }}/> Submitting…</>
-              : <><span style={{ fontSize:13 }}>✓</span> Submit Request</>
-            }
-          </button>
-        </div>
-      </div>
-    </ModalWrap>
-  );
-}
-
-// ─── Lead Detail Modal ────────────────────────────────────────────────────────
-function LeadDetailModal({ lead, onClose }) {
-  const parsePD = msg => {
-    if (!msg) return null;
-    try {
-      const marker = "__PROPERTY_DATA__:";
-      const idx    = msg.indexOf(marker);
-      if (idx === -1) return null;
-      return JSON.parse(msg.substring(idx + marker.length));
-    } catch { return null; }
-  };
-
-  const cleanMsg = msg => {
-    if (!msg) return "";
-    const idx = msg.indexOf("\n--- Property Details ---");
-    if (idx !== -1) return msg.substring(0, idx).trim();
-    const idx2 = msg.indexOf("\n__PROPERTY_DATA__:");
-    if (idx2 !== -1) return msg.substring(0, idx2).trim();
-    return msg;
-  };
-
-  const pd = parsePD(lead.message);
-  const s  = STATUS[lead.status] || STATUS.NEW;
-
-  return (
-    <ModalWrap onClose={onClose} maxW={580}>
-      <MH
-        title={TYPE_LABEL[lead.type] || lead.type}
-        sub={`Request #${lead.id} · ${fmtDateTime(lead.created_at)}`}
-        onClose={onClose}
-      />
-      <div style={{ padding:"22px 26px" }}>
-
-        {/* Status banner */}
-        <div style={{
-          marginBottom:20, padding:"14px 16px", background:s.pill,
-          borderRadius:12, border:`1.5px solid ${s.pillBorder}`,
-          display:"flex", alignItems:"center", gap:14,
-        }}>
-          <div style={{
-            width:38, height:38, borderRadius:10,
-            background:`${s.strip}18`, border:`1.5px solid ${s.strip}35`,
-            display:"flex", alignItems:"center", justifyContent:"center",
-            color:s.strip, flexShrink:0,
-          }}>
-            {TYPE_ICON[lead.type] || <TagIcon />}
-          </div>
-          <div style={{ flex:1 }}>
-            <p style={{
-              fontSize:9.5, color:"#b0a890", fontWeight:600,
-              textTransform:"uppercase", letterSpacing:"0.8px", margin:"0 0 5px",
-            }}>Request status</p>
-            <span style={{
-              background:`${s.strip}16`, color:s.color,
-              border:`1.5px solid ${s.strip}35`,
-              padding:"3px 13px", borderRadius:999,
-              fontSize:11, fontWeight:700,
-              letterSpacing:"0.4px", textTransform:"uppercase",
-            }}>{s.label}</span>
-          </div>
-          <p style={{
-            fontSize:12.5, color:"#6b6248", lineHeight:1.65,
-            maxWidth:220, margin:0,
-            fontFamily:"'Cormorant Garamond',Georgia,serif", fontStyle:"italic",
-          }}>
-            {lead.status==="NEW"&&!lead.assigned_agent_id && "Your request has been received. An admin will assign an agent shortly."}
-            {lead.status==="NEW"&&lead.assigned_agent_id  && "An agent is reviewing your request."}
-            {lead.status==="IN_PROGRESS"                  && "Your agent is actively working on this. You will be contacted soon."}
-            {lead.status==="DONE"                         && "Request completed successfully. Thank you!"}
-            {lead.status==="REJECTED"                     && "This request could not be fulfilled. Feel free to submit a new one."}
-          </p>
-        </div>
-
-        {/* Details grid */}
-        <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:8, marginBottom:16 }}>
-          {[
-            { label:"Type",           value: TYPE_LABEL[lead.type] || lead.type },
-            { label:"Source",         value: SOURCE_LABEL[lead.source] || lead.source },
-            { label:"Preferred date", value: fmtDate(lead.preferred_date) },
-            { label:"Assigned agent", value: lead.agent_name || (lead.assigned_agent_id ? `Agent #${lead.assigned_agent_id}` : "Not assigned yet") },
-          ].map(({ label, value }) => (
-            <div key={label} style={{
-              background:"#fff", borderRadius:11,
-              padding:"11px 14px", border:"1.5px solid #e8e2d6",
-            }}>
-              <p style={{
-                fontSize:9.5, color:"#b0a890", fontWeight:600,
-                textTransform:"uppercase", letterSpacing:"0.8px", marginBottom:5,
-              }}>{label}</p>
-              <p style={{
-                fontSize:13.5, fontWeight:600, color:"#1a1714", margin:0,
-                fontFamily:"'Cormorant Garamond',Georgia,serif",
-              }}>{value}</p>
-            </div>
-          ))}
-        </div>
-
-        {/* Property data */}
-        {pd && (
-          <div style={{
-            background:"rgba(201,184,122,0.06)",
-            border:"1.5px solid rgba(201,184,122,0.18)",
-            borderRadius:12, padding:"14px 16px", marginBottom:14,
-          }}>
-            <p style={{
-              fontSize:9.5, fontWeight:700, color:"#c9b87a",
-              textTransform:"uppercase", letterSpacing:"0.8px",
-              marginBottom:10, display:"flex", alignItems:"center", gap:5,
-            }}>
-              <HomeIcon /> Property details
-            </p>
-            <div style={{ display:"grid", gridTemplateColumns:"1fr 1fr", gap:8 }}>
-              {pd.title && (
-                <div style={{
-                  background:"#fff", borderRadius:8, padding:"8px 12px",
-                  border:"1px solid #e8e2d6", gridColumn:"span 2",
-                }}>
-                  <p style={{ fontSize:10, color:"#b0a890", margin:"0 0 3px", textTransform:"uppercase", letterSpacing:"0.6px" }}>Title</p>
-                  <p style={{ fontSize:14, fontWeight:600, margin:0, fontFamily:"'Cormorant Garamond',Georgia,serif", color:"#1a1714" }}>{pd.title}</p>
-                </div>
-              )}
-              {[
-                pd.type        && { icon:<TagIcon/>,      text: pd.type },
-                pd.city        && { icon:<PinIcon/>,      text: pd.city },
-                pd.area_sqm    && { icon:<AreaIcon/>,     text: `${pd.area_sqm} m²` },
-                pd.bedrooms    && { icon:<BedIcon/>,      text: `${pd.bedrooms} bedrooms` },
-                pd.bathrooms   && { icon:null,            text: `${pd.bathrooms} bathrooms` },
-                pd.floor       && { icon:null,            text: `Floor ${pd.floor}${pd.total_floors ? ` / ${pd.total_floors}` : ""}` },
-                pd.year_built  && { icon:<CalendarIcon/>, text: `Built: ${pd.year_built}` },
-                pd.price       && {
-                  icon: null,
-                  text: `€${Number(pd.price).toLocaleString("de-DE")} ${pd.currency}${  lead.type === "RENT" && pd.price_period ? ` / ${pd.price_period}` : ""}`,
-                  bold: true,
-                },
-                pd.price_per_sqm && {
-                  icon: null,
-                  text: `€${Number(pd.price_per_sqm).toLocaleString("de-DE")} / m²`,
-                },
-              ].filter(Boolean).map((item, i) => (
-                <span key={i} style={{
-                  fontSize:13, color:"#4a4438",
-                  display:"flex", alignItems:"center", gap:5,
-                  padding:"6px 10px", background:"#fff",
-                  borderRadius:8, border:"1px solid #e8e2d6",
-                  fontWeight: item.bold ? 600 : 400,
-                }}>
-                  {item.icon} {item.text}
-                </span>
-              ))}
-            </div>
-            {pd.description && (
-              <div style={{
-                marginTop:8, padding:"8px 12px",
-                background:"#fff", borderRadius:8, border:"1px solid #e8e2d6",
-              }}>
-                <p style={{ fontSize:10, color:"#b0a890", margin:"0 0 3px", textTransform:"uppercase", letterSpacing:"0.6px" }}>Notes</p>
-                <p style={{ fontSize:13, color:"#4a4438", margin:0, lineHeight:1.6 }}>{pd.description}</p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Message */}
-        {lead.message && cleanMsg(lead.message) && (
-          <div style={{
-            background:"#fff", border:"1.5px solid #e8e2d6",
-            borderRadius:12, padding:"14px 16px",
-          }}>
-            <p style={{
-              fontSize:9.5, color:"#b0a890", fontWeight:600,
-              textTransform:"uppercase", letterSpacing:"0.8px", marginBottom:8,
-            }}>Your message</p>
-            <p style={{
-              fontSize:14.5, color:"#3c3830", lineHeight:1.85,
-              fontStyle:"italic", margin:0,
-              fontFamily:"'Cormorant Garamond',Georgia,serif",
-            }}>"{cleanMsg(lead.message)}"</p>
-          </div>
-        )}
-
-        <div style={{
-          borderTop:"1px solid #e8e2d6", paddingTop:16,
-          marginTop:18, display:"flex", justifyContent:"flex-end",
-        }}>
-          <button onClick={onClose} className="cl-btn"
-            style={{
-              padding:"10px 22px", borderRadius:10,
-              border:"1.5px solid #e4ddd0", background:"transparent",
-              color:"#6b6248", fontSize:13.5, fontWeight:500,
-              cursor:"pointer", fontFamily:"inherit",
-            }}>
-            Close
-          </button>
-        </div>
-      </div>
-    </ModalWrap>
-  );
-}
-
-// ─── Status config ────────────────────────────────────────────────────────────
-const STATUS = {
-  NEW:         { strip:"#c9b87a", pill:"rgba(201,184,122,0.12)", pillBorder:"rgba(201,184,122,0.28)", color:"#a8923e", label:"New"         },
-  IN_PROGRESS: { strip:"#7eb8a4", pill:"rgba(126,184,164,0.12)", pillBorder:"rgba(126,184,164,0.28)", color:"#2a8068", label:"In Progress" },
-  DONE:        { strip:"#a4b07e", pill:"rgba(164,176,126,0.12)", pillBorder:"rgba(164,176,126,0.28)", color:"#5a6a38", label:"Done"        },
-  REJECTED:    { strip:"#c07050", pill:"rgba(192,112,80,0.12)",  pillBorder:"rgba(192,112,80,0.28)",  color:"#8b4030", label:"Rejected"    },
-};
-
-// ─── Lead Card ────────────────────────────────────────────────────────────────
-function LeadCard({ lead, onClick, idx }) {
-  const parsePD = msg => {
-    if (!msg) return null;
-    try {
-      const marker = "__PROPERTY_DATA__:";
-      const idx    = msg.indexOf(marker);
-      if (idx === -1) return null;
-      return JSON.parse(msg.substring(idx + marker.length));
-    } catch { return null; }
-  };
-
-  const pd = parsePD(lead.message);
-  const s  = STATUS[lead.status] || STATUS.NEW;
-
-  return (
-    <div className="cl-card" onClick={onClick}
-      style={{
-        background:"#fff", borderRadius:14, overflow:"hidden",
-        boxShadow:"0 2px 14px rgba(20,16,10,0.08)",
-        border:"1.5px solid #ece6da", cursor:"pointer", display:"flex",
-        animation:`cl-card-in 0.38s ease ${Math.min(idx*0.06,0.4)}s both`,
-      }}>
-
-      {/* Left accent strip */}
-      <div style={{ width:4, background:`linear-gradient(to bottom,${s.strip},${s.strip}66)`, flexShrink:0 }}/>
-
-      {/* Icon column */}
-      <div style={{
-        width:60, flexShrink:0,
-        display:"flex", flexDirection:"column", alignItems:"center",
-        justifyContent:"center", gap:7, padding:"14px 8px",
-        background:`${s.strip}07`, borderRight:"1.5px solid #f0ece3",
-      }}>
-        <div style={{
-          color:s.strip, width:28, height:28, borderRadius:8,
-          background:`${s.strip}12`, border:`1.5px solid ${s.strip}28`,
-          display:"flex", alignItems:"center", justifyContent:"center",
-        }}>
-          {TYPE_ICON[lead.type] || <TagIcon />}
-        </div>
-        <span style={{
-          fontSize:8.5, fontWeight:700, color:s.color,
-          textTransform:"uppercase", letterSpacing:"0.5px",
-          textAlign:"center", lineHeight:1.3,
-          background:`${s.strip}12`, padding:"2px 6px",
-          borderRadius:5, border:`1px solid ${s.strip}25`,
-        }}>
-          {s.label}
-        </span>
-      </div>
-
-      {/* Main content */}
-      <div style={{
-        flex:1, padding:"13px 18px",
-        display:"flex", flexDirection:"column", justifyContent:"space-between", minWidth:0,
-      }}>
-        <div>
-          <div style={{
-            display:"flex", justifyContent:"space-between",
-            alignItems:"flex-start", gap:12, marginBottom:5,
-          }}>
-            <div style={{ minWidth:0 }}>
-              <h3 style={{
-                margin:"0 0 3px", fontSize:15.5, fontWeight:700,
-                color:"#1a1714", fontFamily:"'Cormorant Garamond',Georgia,serif",
-                letterSpacing:"-0.1px", lineHeight:1.2,
-                overflow:"hidden", textOverflow:"ellipsis", whiteSpace:"nowrap",
-              }}>
-                {TYPE_LABEL[lead.type] || lead.type}
-                {pd?.title && (
-                  <span style={{ fontWeight:400, color:"#9a8c6e", fontSize:13.5 }}>
-                    {" "}— {pd.title}
-                  </span>
-                )}
-              </h3>
-              <p style={{
-                fontSize:11.5, color:"#b0a890", margin:0,
-                display:"flex", alignItems:"center", gap:8, flexWrap:"wrap",
-              }}>
-                <span>#{lead.id}</span>
-                <span style={{ display:"flex", alignItems:"center", gap:3 }}>
-                  <ClockIcon />{fmtDate(lead.created_at)}
-                </span>
-                {pd?.city && (
-                  <span style={{ display:"flex", alignItems:"center", gap:3 }}>
-                    <PinIcon />{pd.city}
-                  </span>
-                )}
-              </p>
-            </div>
-
-            {pd?.price && (
-              <div style={{ flexShrink:0, textAlign:"right" }}>
-                <div style={{
-                  fontSize:17, fontWeight:700, color:"#1a1714",
-                  fontFamily:"'Cormorant Garamond',Georgia,serif", letterSpacing:"-0.3px",
-                }}>
-                  €{Number(pd.price).toLocaleString("de-DE")}
-                  {pd.price_period && lead.type === "RENT" && (
-                    <span style={{ fontSize:11, fontWeight:400, color:"#9a8c6e" }}>
-                      /{pd.price_period}
-                    </span>
-                  )}
-                </div>
-                {pd.price_per_sqm && (
-                  <div style={{ fontSize:11, color:"#9a8c6e" }}>
-                    €{Number(pd.price_per_sqm).toLocaleString("de-DE")}/m²
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* Footer */}
-        <div style={{
-          display:"flex", gap:14, paddingTop:9,
-          borderTop:"1px solid #f0ece3", flexWrap:"wrap", alignItems:"center",
-        }}>
-          {pd?.area_sqm && (
-            <span style={{ fontSize:12, color:"#9a8c6e", display:"flex", alignItems:"center", gap:4 }}>
-              <AreaIcon />{pd.area_sqm} m²
-            </span>
-          )}
-          {pd?.bedrooms && (
-            <span style={{ fontSize:12, color:"#9a8c6e", display:"flex", alignItems:"center", gap:4 }}>
-              <BedIcon />{pd.bedrooms} beds
-            </span>
-          )}
-          {lead.preferred_date && (
-            <span style={{ fontSize:12, color:"#9a8c6e", display:"flex", alignItems:"center", gap:4 }}>
-              <CalendarIcon />{fmtDate(lead.preferred_date)}
-            </span>
-          )}
-          <span style={{ fontSize:12, color:"#9a8c6e", display:"flex", alignItems:"center", gap:4 }}>
-            <UserIcon />
-            {lead.agent_name || (lead.assigned_agent_id ? `Agent #${lead.assigned_agent_id}` : "Not assigned yet")}
-          </span>
-          <span style={{
-            marginLeft:"auto", fontSize:11.5, color:"#c9b87a",
-            fontWeight:600, display:"flex", alignItems:"center", gap:4,
-          }}>
-            View details <ArrowRightIcon />
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Pagination ───────────────────────────────────────────────────────────────
-const PGB = (active, disabled) => ({
-  padding:"7px 13px", borderRadius:9,
-  border:`1.5px solid ${active ? "#1a1714" : "#e4ddd0"}`,
-  background:active ? "#1a1714" : "transparent",
-  color:active ? "#f5f0e8" : disabled ? "#d4ccbe" : "#6b6248",
-  cursor:disabled ? "not-allowed" : "pointer",
-  fontSize:13, fontWeight:active ? 600 : 400,
-  fontFamily:"'DM Sans',sans-serif",
-  opacity:disabled ? 0.5 : 1, transition:"all 0.14s",
-});
-
-function Pagination({ page, totalPages, onChange }) {
-  if (totalPages <= 1) return null;
-  const pages   = Array.from({ length:totalPages }, (_, i) => i);
-  const visible = pages.filter(p => p===0 || p===totalPages-1 || Math.abs(p-page)<=1);
-  return (
-    <div style={{ display:"flex", justifyContent:"center", gap:4, marginTop:44, flexWrap:"wrap" }}>
-      <button disabled={page===0} onClick={() => onChange(page-1)} style={PGB(false,page===0)}>‹</button>
-      {visible.map((p, i) => {
-        const gap = visible[i-1] != null && p - visible[i-1] > 1;
-        return (
-          <span key={p} style={{ display:"flex", gap:4 }}>
-            {gap && <span style={{ padding:"7px 4px", color:"#b0a890", fontSize:13 }}>…</span>}
-            <button onClick={() => onChange(p)} style={PGB(p===page, false)}>{p+1}</button>
-          </span>
-        );
-      })}
-      <button disabled={page===totalPages-1} onClick={() => onChange(page+1)} style={PGB(false,page===totalPages-1)}>›</button>
-    </div>
-  );
-}
-
-// ─── Main Page ────────────────────────────────────────────────────────────────
+ 
+import { CSS } from "../../components/client/leads/leadsConstants";
+import { Toast, Skeleton, Pagination } from "../../components/client/leads/LeadsUI";
+import { PlusIcon, ChartIcon } from "../../components/client/leads/LeadsIcons";
+import LeadCard from "../../components/client/leads/LeadCard";
+import CreateLeadModal from "../../components/client/leads/CreateLeadModal";
+import LeadDetailModal from "../../components/client/leads/LeadDetailModal";
+ 
 export default function ClientLeads() {
-  const { user }                               = useContext(AuthContext);
-  const [leads,        setLeads]               = useState([]);
-  const [loading,      setLoading]             = useState(true);
-  const [page,         setPage]                = useState(0);
-  const [totalPages,   setTotalPages]          = useState(0);
-  const [createOpen,   setCreateOpen]          = useState(false);
-  const [selectedLead, setSelectedLead]        = useState(null);
-  const [toast,        setToast]               = useState(null);
-
-  const notify = useCallback((msg, type="success") =>
-    setToast({ msg, type, key:Date.now() }), []);
-
+  const { user }                        = useContext(AuthContext);
+  const [leads,        setLeads]        = useState([]);
+  const [loading,      setLoading]      = useState(true);
+  const [page,         setPage]         = useState(0);
+  const [totalPages,   setTotalPages]   = useState(0);
+  const [createOpen,   setCreateOpen]   = useState(false);
+  const [selectedLead, setSelectedLead] = useState(null);
+  const [toast,        setToast]        = useState(null);
+ 
+  const notify = useCallback((msg, type = "success") =>
+    setToast({ msg, type, key: Date.now() }), []);
+ 
   const fetchLeads = useCallback(async () => {
     setLoading(true);
     try {
@@ -1078,167 +32,121 @@ export default function ClientLeads() {
     } catch { notify("Error loading requests", "error"); }
     finally  { setLoading(false); }
   }, [page, notify]);
-
+ 
   useEffect(() => { fetchLeads(); }, [fetchLeads]);
-
+ 
   const stats = {
     total:    leads.length,
-    active:   leads.filter(l => l.status==="NEW" || l.status==="IN_PROGRESS").length,
-    done:     leads.filter(l => l.status==="DONE").length,
-    rejected: leads.filter(l => l.status==="REJECTED").length,
+    active:   leads.filter(l => l.status === "NEW" || l.status === "IN_PROGRESS").length,
+    done:     leads.filter(l => l.status === "DONE").length,
+    rejected: leads.filter(l => l.status === "REJECTED").length,
   };
-
+ 
   return (
     <MainLayout role="client">
       <style>{CSS}</style>
       <div className="cl">
-
+ 
         {/* Hero */}
         <div style={{
-          background:"linear-gradient(160deg,#141210 0%,#1e1a14 45%,#241e16 100%)",
-          padding:"36px 32px 30px", position:"relative", overflow:"hidden",
+          background: "linear-gradient(160deg,#141210 0%,#1e1a14 45%,#241e16 100%)",
+          padding: "36px 32px 30px", position: "relative", overflow: "hidden",
         }}>
-          <div style={{
-            position:"absolute", inset:0,
-            backgroundImage:"radial-gradient(rgba(255,255,255,0.018) 1px,transparent 1px)",
-            backgroundSize:"22px 22px", pointerEvents:"none",
-          }}/>
-          <div style={{
-            position:"absolute", top:0, left:0, right:0, height:"2px",
-            background:"linear-gradient(90deg,transparent,#c9b87a 30%,#c9b87a 70%,transparent)",
-          }}/>
-
-          <div style={{ position:"relative", zIndex:1, maxWidth:700, margin:"0 auto", textAlign:"center" }}>
-            <h1 style={{
-              margin:"0 0 10px",
-              fontFamily:"'Cormorant Garamond',Georgia,serif",
-              fontSize:"clamp(28px,4vw,44px)", fontWeight:700,
-              color:"#f5f0e8", letterSpacing:"-0.7px", lineHeight:1.1,
-            }}>
+          <div style={{ position: "absolute", inset: 0, backgroundImage: "radial-gradient(rgba(255,255,255,0.018) 1px,transparent 1px)", backgroundSize: "22px 22px", pointerEvents: "none" }}/>
+          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: "2px", background: "linear-gradient(90deg,transparent,#c9b87a 30%,#c9b87a 70%,transparent)" }}/>
+ 
+          <div style={{ position: "relative", zIndex: 1, maxWidth: 700, margin: "0 auto", textAlign: "center" }}>
+            <h1 style={{ margin: "0 0 10px", fontFamily: "'Cormorant Garamond',Georgia,serif", fontSize: "clamp(28px,4vw,44px)", fontWeight: 700, color: "#f5f0e8", letterSpacing: "-0.7px", lineHeight: 1.1 }}>
               My{" "}
-              <span style={{
-                background:"linear-gradient(90deg,#c9b87a,#e8d9a0,#c9b87a)",
-                backgroundSize:"200% auto",
-                WebkitBackgroundClip:"text", WebkitTextFillColor:"transparent", backgroundClip:"text",
-              }}>Requests</span>
+              <span style={{ background: "linear-gradient(90deg,#c9b87a,#e8d9a0,#c9b87a)", backgroundSize: "200% auto", WebkitBackgroundClip: "text", WebkitTextFillColor: "transparent", backgroundClip: "text" }}>Requests</span>
             </h1>
-            <p style={{
-              margin:"0 auto 22px", fontSize:13.5,
-              color:"rgba(245,240,232,0.38)", lineHeight:1.6,
-            }}>
+            <p style={{ margin: "0 auto 22px", fontSize: 13.5, color: "rgba(245,240,232,0.38)", lineHeight: 1.6 }}>
               Track and manage your property requests
             </p>
-
-            <button onClick={() => setCreateOpen(true)} className="cl-btn"
-              style={{
-                display:"inline-flex", alignItems:"center", gap:8,
-                background:"linear-gradient(135deg,#c9b87a 0%,#b0983e 100%)",
-                color:"#1a1714", border:"none", borderRadius:11,
-                padding:"11px 24px", fontSize:13.5, fontWeight:700,
-                cursor:"pointer", fontFamily:"'DM Sans',sans-serif",
-                boxShadow:"0 6px 22px rgba(201,184,122,0.25)",
-              }}>
+ 
+            <button onClick={() => setCreateOpen(true)} className="cl-btn" style={{
+              display: "inline-flex", alignItems: "center", gap: 8,
+              background: "linear-gradient(135deg,#c9b87a 0%,#b0983e 100%)",
+              color: "#1a1714", border: "none", borderRadius: 11,
+              padding: "11px 24px", fontSize: 13.5, fontWeight: 700,
+              cursor: "pointer", fontFamily: "'DM Sans',sans-serif",
+              boxShadow: "0 6px 22px rgba(201,184,122,0.25)",
+            }}>
               <PlusIcon /> New Request
             </button>
-
+ 
             {!loading && leads.length > 0 && (
-              <div style={{
-                display:"flex", gap:8, maxWidth:480,
-                margin:"20px auto 0", justifyContent:"center", flexWrap:"wrap",
-              }}>
+              <div style={{ display: "flex", gap: 8, maxWidth: 480, margin: "20px auto 0", justifyContent: "center", flexWrap: "wrap" }}>
                 {[
-                  { label:"Total",    value:stats.total,    dot:"#c9b87a" },
-                  { label:"Active",   value:stats.active,   dot:"#e2c97e" },
-                  { label:"Done",     value:stats.done,     dot:"#7eb8a4" },
-                  { label:"Rejected", value:stats.rejected, dot:"#c07050" },
+                  { label: "Total",    value: stats.total,    dot: "#c9b87a" },
+                  { label: "Active",   value: stats.active,   dot: "#e2c97e" },
+                  { label: "Done",     value: stats.done,     dot: "#7eb8a4" },
+                  { label: "Rejected", value: stats.rejected, dot: "#c07050" },
                 ].map(stat => (
                   <div key={stat.label} style={{
-                    background:"rgba(245,240,232,0.06)", backdropFilter:"blur(10px)",
-                    borderRadius:11, padding:"9px 16px",
-                    border:"1px solid rgba(245,240,232,0.09)",
-                    display:"flex", flexDirection:"column", alignItems:"center", gap:2,
+                    background: "rgba(245,240,232,0.06)", backdropFilter: "blur(10px)",
+                    borderRadius: 11, padding: "9px 16px",
+                    border: "1px solid rgba(245,240,232,0.09)",
+                    display: "flex", flexDirection: "column", alignItems: "center", gap: 2,
                   }}>
-                    <span style={{
-                      fontSize:22, fontWeight:700, color:stat.dot, lineHeight:1,
-                      fontFamily:"'Cormorant Garamond',Georgia,serif",
-                    }}>{stat.value}</span>
-                    <span style={{
-                      fontSize:9.5, color:"rgba(245,240,232,0.3)", fontWeight:600,
-                      textTransform:"uppercase", letterSpacing:"0.8px",
-                    }}>{stat.label}</span>
+                    <span style={{ fontSize: 22, fontWeight: 700, color: stat.dot, lineHeight: 1, fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{stat.value}</span>
+                    <span style={{ fontSize: 9.5, color: "rgba(245,240,232,0.3)", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.8px" }}>{stat.label}</span>
                   </div>
                 ))}
               </div>
             )}
           </div>
         </div>
-
+ 
         {/* Toolbar */}
         <div style={{
-          background:"#fff", borderBottom:"1.5px solid #e8e2d6",
-          padding:"0 28px", height:46,
-          display:"flex", alignItems:"center", justifyContent:"space-between",
-          gap:12, position:"sticky", top:0, zIndex:100,
-          boxShadow:"0 1px 10px rgba(20,16,10,0.05)",
+          background: "#fff", borderBottom: "1.5px solid #e8e2d6",
+          padding: "0 28px", height: 46,
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          gap: 12, position: "sticky", top: 0, zIndex: 100,
+          boxShadow: "0 1px 10px rgba(20,16,10,0.05)",
         }}>
-          <p style={{ margin:0, fontSize:12.5, color:"#9a8c6e" }}>
-            {loading ? "Loading…" : `${leads.length} request${leads.length!==1?"s":""}`}
+          <p style={{ margin: 0, fontSize: 12.5, color: "#9a8c6e" }}>
+            {loading ? "Loading…" : `${leads.length} request${leads.length !== 1 ? "s" : ""}`}
           </p>
-          <button onClick={() => setCreateOpen(true)} className="cl-btn"
-            style={{
-              padding:"5px 14px", borderRadius:9,
-              background:"linear-gradient(135deg,#c9b87a,#b0983e)",
-              color:"#1a1714", border:"none", fontSize:12, fontWeight:700,
-              cursor:"pointer", fontFamily:"'DM Sans',sans-serif",
-              display:"flex", alignItems:"center", gap:5,
-            }}>
+          <button onClick={() => setCreateOpen(true)} className="cl-btn" style={{
+            padding: "5px 14px", borderRadius: 9,
+            background: "linear-gradient(135deg,#c9b87a,#b0983e)",
+            color: "#1a1714", border: "none", fontSize: 12, fontWeight: 700,
+            cursor: "pointer", fontFamily: "'DM Sans',sans-serif",
+            display: "flex", alignItems: "center", gap: 5,
+          }}>
             <PlusIcon /> New Request
           </button>
         </div>
-
+ 
         {/* Content */}
-        <div style={{ padding:"20px 24px", maxWidth:1440, margin:"0 auto" }}>
+        <div style={{ padding: "20px 24px", maxWidth: 1440, margin: "0 auto" }}>
           {loading && <Skeleton />}
-
+ 
           {!loading && leads.length === 0 && (
-            <div style={{
-              textAlign:"center", padding:"80px 32px",
-              color:"#9a8c6e", fontFamily:"'DM Sans',sans-serif",
-            }}>
-              <div style={{
-                width:52, height:52, borderRadius:"50%",
-                background:"#f0ece3", border:"1.5px solid #e4ddd0",
-                display:"flex", alignItems:"center", justifyContent:"center",
-                margin:"0 auto 18px", color:"#b0a890",
-              }}>
+            <div style={{ textAlign: "center", padding: "80px 32px", color: "#9a8c6e", fontFamily: "'DM Sans',sans-serif" }}>
+              <div style={{ width: 52, height: 52, borderRadius: "50%", background: "#f0ece3", border: "1.5px solid #e4ddd0", display: "flex", alignItems: "center", justifyContent: "center", margin: "0 auto 18px", color: "#b0a890" }}>
                 <ChartIcon />
               </div>
-              <p style={{
-                fontSize:18, fontWeight:700, color:"#4a4438", marginBottom:6,
-                fontFamily:"'Cormorant Garamond',Georgia,serif", letterSpacing:"-0.2px",
-              }}>No requests yet</p>
-              <p style={{ fontSize:13, marginBottom:24, color:"#9a8c6e" }}>
-                Submit your first request — an agent will get back to you.
-              </p>
-              <button onClick={() => setCreateOpen(true)} className="cl-btn"
-                style={{
-                  padding:"11px 28px",
-                  background:"linear-gradient(135deg,#c9b87a,#b0983e)",
-                  color:"#1a1714", border:"none", borderRadius:11,
-                  fontSize:13.5, fontWeight:700, cursor:"pointer",
-                  fontFamily:"inherit", display:"inline-flex", alignItems:"center", gap:8,
-                }}>
+              <p style={{ fontSize: 18, fontWeight: 700, color: "#4a4438", marginBottom: 6, fontFamily: "'Cormorant Garamond',Georgia,serif", letterSpacing: "-0.2px" }}>No requests yet</p>
+              <p style={{ fontSize: 13, marginBottom: 24, color: "#9a8c6e" }}>Submit your first request — an agent will get back to you.</p>
+              <button onClick={() => setCreateOpen(true)} className="cl-btn" style={{
+                padding: "11px 28px", background: "linear-gradient(135deg,#c9b87a,#b0983e)",
+                color: "#1a1714", border: "none", borderRadius: 11,
+                fontSize: 13.5, fontWeight: 700, cursor: "pointer",
+                fontFamily: "inherit", display: "inline-flex", alignItems: "center", gap: 8,
+              }}>
                 <PlusIcon /> New Request
               </button>
             </div>
           )}
-
+ 
           {!loading && leads.length > 0 && (
             <>
-              <div style={{ display:"flex", flexDirection:"column", gap:12 }}>
+              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
                 {leads.map((lead, i) => (
-                  <LeadCard key={lead.id} lead={lead} idx={i}
-                    onClick={() => setSelectedLead(lead)} />
+                  <LeadCard key={lead.id} lead={lead} idx={i} onClick={() => setSelectedLead(lead)} />
                 ))}
               </div>
               <Pagination page={page} totalPages={totalPages} onChange={setPage} />
@@ -1246,15 +154,11 @@ export default function ClientLeads() {
           )}
         </div>
       </div>
-
+ 
       {createOpen && (
         <CreateLeadModal
           onClose={() => setCreateOpen(false)}
-          onSuccess={() => {
-            setCreateOpen(false);
-            fetchLeads();
-            notify("Request submitted. Your agent will contact you shortly. ✓");
-          }}
+          onSuccess={() => { setCreateOpen(false); fetchLeads(); notify("Request submitted. Your agent will contact you shortly. ✓"); }}
           notify={notify}
         />
       )}
@@ -1267,3 +171,4 @@ export default function ClientLeads() {
     </MainLayout>
   );
 }
+ 

--- a/src/pages/client/MyApplications.jsx
+++ b/src/pages/client/MyApplications.jsx
@@ -1,343 +1,11 @@
 import { useEffect, useState, useCallback } from "react";
 import MainLayout from "../../components/layout/Layout";
 import api from "../../api/axios";
-
-// ─── Icons ────────────────────────────────────────────────────────────────────
-const CalendarIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <rect width="18" height="18" x="3" y="4" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/>
-    <line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
-  </svg>
-);
-const EuroIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M4 10h12"/><path d="M4 14h9"/><path d="M19 6a7 7 0 1 0 0 12"/>
-  </svg>
-);
-const HomeIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>
-  </svg>
-);
-const ClockIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
-  </svg>
-);
-const CloseIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
-  </svg>
-);
-const ChevronLeftIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-    <path d="m15 18-6-6 6-6"/>
-  </svg>
-);
-const ChevronRightIcon = () => (
-  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-    <path d="m9 18 6-6-6-6"/>
-  </svg>
-);
-
-// ─── Toast ────────────────────────────────────────────────────────────────────
-function Toast({ msg, type = "success", onDone }) {
-  useEffect(() => {
-    const t = setTimeout(onDone, 3200);
-    return () => clearTimeout(t);
-  }, [onDone]);
-  return (
-    <div style={{
-      position: "fixed", bottom: 28, right: 28, zIndex: 9999,
-      background: type === "error" ? "#fee2e2" : "#ecfdf5",
-      color: type === "error" ? "#b91c1c" : "#047857",
-      padding: "12px 20px", borderRadius: 10, fontSize: 13.5, fontWeight: 500,
-      boxShadow: "0 4px 18px rgba(0,0,0,0.12)", maxWidth: 340,
-    }}>{msg}</div>
-  );
-}
-
-// ─── Confirm Cancel Modal ─────────────────────────────────────────────────────
-function ConfirmCancelModal({ onConfirm, onClose, loading }) {
-  useEffect(() => {
-    const h = (e) => e.key === "Escape" && onClose();
-    window.addEventListener("keydown", h);
-    return () => window.removeEventListener("keydown", h);
-  }, [onClose]);
-
-  useEffect(() => {
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, []);
-
-  return (
-    <div
-      onClick={e => e.target === e.currentTarget && onClose()}
-      style={{ position: "fixed", inset: 0, background: "rgba(20,20,10,0.72)", backdropFilter: "blur(4px)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: "20px", animation: "fadeInOverlay 0.2s ease" }}
-    >
-      <div style={{ background: "#faf8f3", borderRadius: "18px", width: "100%", maxWidth: "400px", boxShadow: "0 24px 64px rgba(0,0,0,0.35)", animation: "slideUpModal 0.25s ease", padding: "32px 28px 26px" }}>
-        <div style={{ textAlign: "center", marginBottom: 24 }}>
-          <div style={{ fontSize: "40px", marginBottom: "12px" }}>⚠️</div>
-          <p style={{ fontWeight: 800, fontSize: "17px", margin: "0 0 8px", color: "#2c2c1e" }}>Anulo aplikimin?</p>
-          <p style={{ fontSize: "13.5px", color: "#8a8469", margin: 0, lineHeight: 1.5 }}>Ky veprim nuk mund të kthehet prapa.</p>
-        </div>
-        <div style={{ display: "flex", gap: 10 }}>
-          <button onClick={onClose}
-            style={{ flex: 1, padding: "11px", borderRadius: "10px", border: "1.5px solid #d9d4c7", background: "#fff", color: "#5a5f3a", fontWeight: 600, fontSize: "14px", cursor: "pointer", fontFamily: "inherit" }}>
-            Jo, mbaje
-          </button>
-          <button onClick={onConfirm} disabled={loading}
-            style={{ flex: 1, padding: "11px", borderRadius: "10px", border: "none", background: loading ? "#c5a08a" : "#8b4513", color: "#fff", fontWeight: 700, fontSize: "14px", cursor: loading ? "not-allowed" : "pointer", fontFamily: "inherit" }}>
-            {loading ? "Duke anuluar..." : "Po, anulo"}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─── Listing Detail Inline ────────────────────────────────────────────────────
-function ListingDetail({ listingId }) {
-  const [listing, setListing] = useState(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const res = await api.get(`/api/rentals/listings/${listingId}`);
-        if (!cancelled) setListing(res.data);
-      } catch {}
-      finally { if (!cancelled) setLoading(false); }
-    };
-    load();
-    return () => { cancelled = true; };
-  }, [listingId]);
-
-  if (loading) return (
-    <div style={{ display: "flex", gap: 6, alignItems: "center", fontSize: "12px", color: "#a0997e", marginTop: 6 }}>
-      <div style={{ width: 12, height: 12, border: "2px solid #e5e0d4", borderTop: "2px solid #5a5f3a", borderRadius: "50%", animation: "spin .7s linear infinite" }} />
-      Duke ngarkuar detajet...
-    </div>
-  );
-
-  if (!listing) return <div style={{ marginTop: 6, fontSize: "12px", color: "#a0997e" }}>Listing #{listingId}</div>;
-
-  const fmtMoney = (v) => v != null ? `€${Number(v).toLocaleString("de-DE")}` : null;
-  const fmtDate  = (d) => d ? new Date(d).toLocaleDateString("sq-AL") : null;
-
-  return (
-    <div style={{ marginTop: 10, background: "#f5f2eb", border: "1px solid #e5e0d4", borderRadius: "10px", padding: "12px 16px" }}>
-      <p style={{ fontWeight: 700, fontSize: "13.5px", margin: "0 0 6px", color: "#2c2c1e" }}>
-        {listing.title || `Listing #${listing.id}`}
-      </p>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 18px", fontSize: "12.5px", color: "#6b6651" }}>
-        {listing.price != null && (
-          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
-            <EuroIcon />{fmtMoney(listing.price)} / {(listing.price_period || "monthly").toLowerCase()}
-          </span>
-        )}
-        {listing.deposit != null && (
-          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
-            <EuroIcon />Depozita: {fmtMoney(listing.deposit)}
-          </span>
-        )}
-        {listing.min_lease_months && (
-          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
-            <ClockIcon />Min. {listing.min_lease_months} muaj
-          </span>
-        )}
-        {listing.available_from && (
-          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
-            <CalendarIcon />Nga {fmtDate(listing.available_from)}
-          </span>
-        )}
-        {listing.available_until && (
-          <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
-            <CalendarIcon />Deri {fmtDate(listing.available_until)}
-          </span>
-        )}
-      </div>
-      {listing.description && (
-        <p style={{ margin: "8px 0 0", fontSize: "12.5px", color: "#4a4a36", lineHeight: 1.6 }}>
-          {listing.description}
-        </p>
-      )}
-    </div>
-  );
-}
-
-// ─── Application Card ─────────────────────────────────────────────────────────
-function ApplicationCard({ app, onCancel }) {
-  const [cancelling,  setCancelling]  = useState(false);
-  const [showConfirm, setShowConfirm] = useState(false);
-
-  const STATUS_CONFIG = {
-    PENDING:   { bg: "#fffbeb", color: "#c9a84c", border: "#f0d878", label: "Në pritje", icon: "⏳", strip: "#c9a84c" },
-    APPROVED:  { bg: "#edf5f0", color: "#2a6049", border: "#a3c9b0", label: "Aprovuar",  icon: "✅", strip: "#2a6049" },
-    REJECTED:  { bg: "#fef2f2", color: "#8b4513", border: "#f5c6a0", label: "Refuzuar",  icon: "❌", strip: "#8b4513" },
-    CANCELLED: { bg: "#f5f2eb", color: "#8a8469", border: "#d9d4c7", label: "Anuluar",   icon: "🚫", strip: "#a0997e" },
-  };
-
-  const s       = STATUS_CONFIG[app.status] || STATUS_CONFIG.CANCELLED;
-  const fmtDate = (d) => d ? new Date(d).toLocaleDateString("sq-AL", { day: "2-digit", month: "long", year: "numeric" }) : "—";
-  const fmtMon  = (v) => v != null ? `€${Number(v).toLocaleString("de-DE")}` : null;
-
-  const handleConfirmCancel = async () => {
-    setCancelling(true);
-    await onCancel(app.id);
-    setCancelling(false);
-    setShowConfirm(false);
-  };
-
-  return (
-    <>
-      <div
-        style={{ background: "#fff", borderRadius: "14px", overflow: "hidden", boxShadow: "0 2px 12px rgba(90,95,58,0.10)", border: "1px solid #ede9df", transition: "transform 0.18s, box-shadow 0.18s" }}
-        onMouseEnter={e => { e.currentTarget.style.transform = "translateY(-3px)"; e.currentTarget.style.boxShadow = "0 8px 28px rgba(90,95,58,0.18)"; }}
-        onMouseLeave={e => { e.currentTarget.style.transform = "translateY(0)"; e.currentTarget.style.boxShadow = "0 2px 12px rgba(90,95,58,0.10)"; }}
-      >
-        {/* status colour strip — identical to PropertyCard listing badge pattern */}
-        <div style={{ height: "4px", background: s.strip }} />
-
-        <div style={{ padding: "18px 22px" }}>
-          {/* Top row */}
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "12px", marginBottom: "14px" }}>
-            <div>
-              <div style={{ fontSize: "11px", fontWeight: 700, color: "#a0997e", textTransform: "uppercase", letterSpacing: "0.6px", marginBottom: "4px" }}>
-                Aplikim #{app.id}
-              </div>
-              <div style={{ display: "flex", alignItems: "center", gap: "5px", color: "#8a8469", fontSize: "12.5px" }}>
-                <CalendarIcon />
-                <span>Dërguar më {fmtDate(app.created_at)}</span>
-              </div>
-            </div>
-            {/* status badge — same rounded pill as BrowseProperties listingBadge */}
-            <span style={{ background: s.bg, color: s.color, border: `1px solid ${s.border}`, padding: "3px 12px", borderRadius: "20px", fontSize: "12px", fontWeight: 700, display: "flex", alignItems: "center", gap: "4px", flexShrink: 0 }}>
-              {s.icon} {s.label}
-            </span>
-          </div>
-
-          {/* Listing section */}
-          <div style={{ marginBottom: "12px" }}>
-            <div style={{ display: "flex", alignItems: "center", gap: "5px", fontSize: "11.5px", fontWeight: 700, color: "#6b6651", textTransform: "uppercase", letterSpacing: "0.5px", marginBottom: "2px" }}>
-              <HomeIcon /> Listing
-            </div>
-            <ListingDetail listingId={app.listing_id} />
-          </div>
-
-          {/* Income / move-in info bar */}
-          {(app.income != null || app.move_in_date) && (
-            <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 20px", padding: "10px 14px", background: "#f5f2eb", borderRadius: "8px", border: "1px solid #e5e0d4", marginBottom: "12px" }}>
-              {app.income != null && (
-                <span style={{ fontSize: "12.5px", color: "#4a4a36", display: "flex", alignItems: "center", gap: 4 }}>
-                  <EuroIcon /> Të ardhura: <strong>{fmtMon(app.income)}/muaj</strong>
-                </span>
-              )}
-              {app.move_in_date && (
-                <span style={{ fontSize: "12.5px", color: "#4a4a36", display: "flex", alignItems: "center", gap: 4 }}>
-                  <CalendarIcon /> Hyrja: <strong>{fmtDate(app.move_in_date)}</strong>
-                </span>
-              )}
-            </div>
-          )}
-
-          {/* Message quote */}
-          {app.message && (
-            <div style={{ padding: "10px 14px", background: "#f5f2eb", borderLeft: "3px solid #a3a380", borderRadius: "0 8px 8px 0", marginBottom: "12px" }}>
-              <p style={{ margin: 0, fontSize: "13px", color: "#4a4a36", fontStyle: "italic", lineHeight: 1.6 }}>"{app.message}"</p>
-            </div>
-          )}
-
-          {/* Status banners */}
-          {app.status === "APPROVED" && (
-            <div style={{ background: "#edf5f0", border: "1px solid #a3c9b0", borderRadius: "10px", padding: "12px 14px", fontSize: "13px", color: "#2a6049", display: "flex", alignItems: "center", gap: 8, marginBottom: "4px" }}>
-              🎉 <span>Aplikimi juaj u aprovua! Agjenti do t'ju kontaktojë së shpejti.</span>
-            </div>
-          )}
-          {app.status === "CANCELLED" && (
-            <div style={{ background: "#f5f2eb", border: "1px solid #d9d4c7", borderRadius: "10px", padding: "12px 14px", fontSize: "13px", color: "#8a8469", display: "flex", alignItems: "center", gap: 8, marginBottom: "4px" }}>
-              🚫 <span>Ky aplikim është anuluar.</span>
-            </div>
-          )}
-          {app.status === "REJECTED" && (
-            <div style={{ background: "#fff5ee", border: "1px solid #f5c6a0", borderRadius: "10px", padding: "12px 14px", fontSize: "13px", color: "#8b4513", display: "flex", alignItems: "center", gap: 8, marginBottom: "4px" }}>
-              ❌ <span>Aplikimi juaj u refuzua.</span>
-            </div>
-          )}
-
-          {/* Cancel button — PENDING only */}
-          {app.status === "PENDING" && (
-            <div style={{ marginTop: "14px" }}>
-              <button
-                onClick={() => setShowConfirm(true)}
-                style={{ padding: "8px 18px", borderRadius: "8px", border: "1.5px solid #d9c4b0", background: "#fff", color: "#8b4513", fontSize: "13px", fontWeight: 600, cursor: "pointer", fontFamily: "inherit", transition: "all 0.15s", display: "flex", alignItems: "center", gap: 6 }}
-                onMouseEnter={e => { e.currentTarget.style.background = "#fff5ee"; }}
-                onMouseLeave={e => { e.currentTarget.style.background = "#fff"; }}
-              >
-                <CloseIcon /> Anulo aplikimin
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {showConfirm && (
-        <ConfirmCancelModal
-          loading={cancelling}
-          onConfirm={handleConfirmCancel}
-          onClose={() => setShowConfirm(false)}
-        />
-      )}
-    </>
-  );
-}
-
-// ─── Pagination ───────────────────────────────────────────────────────────────
-function Pagination({ page, totalPages, onLoadApps, statusFilter }) {
-  if (totalPages <= 1) return null;
-  const pages   = Array.from({ length: totalPages }, (_, i) => i);
-  const visible = pages.filter(p => p === 0 || p === totalPages - 1 || Math.abs(p - page) <= 1);
-  return (
-    <div style={{ display: "flex", justifyContent: "center", gap: "6px", marginTop: "36px", flexWrap: "wrap" }}>
-      <button disabled={page === 0} onClick={() => onLoadApps(page - 1, statusFilter)}
-        style={S.pageBtn(false, page === 0)}><ChevronLeftIcon /></button>
-      {visible.map((p, i) => {
-        const gap = visible[i - 1] != null && p - visible[i - 1] > 1;
-        return (
-          <span key={p} style={{ display: "flex", gap: "6px" }}>
-            {gap && <span style={{ padding: "6px 4px", color: "#8a8469" }}>…</span>}
-            <button onClick={() => onLoadApps(p, statusFilter)} style={S.pageBtn(p === page, false)}>{p + 1}</button>
-          </span>
-        );
-      })}
-      <button disabled={page === totalPages - 1} onClick={() => onLoadApps(page + 1, statusFilter)}
-        style={S.pageBtn(false, page === totalPages - 1)}><ChevronRightIcon /></button>
-    </div>
-  );
-}
-
-// ─── Skeleton ─────────────────────────────────────────────────────────────────
-function Skeleton() {
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
-      {Array.from({ length: 3 }).map((_, i) => (
-        <div key={i} style={{ background: "#f0ece3", borderRadius: "14px", height: "160px", animation: "pulse 1.4s ease-in-out infinite" }} />
-      ))}
-    </div>
-  );
-}
-
-// ─── Status filter config ─────────────────────────────────────────────────────
-const STATUS_FILTERS = [
-  { value: "",          label: "Të gjitha" },
-  { value: "PENDING",   label: "Në pritje"  },
-  { value: "APPROVED",  label: "Aprovuar"   },
-  { value: "REJECTED",  label: "Refuzuar"   },
-  { value: "CANCELLED", label: "Anuluar"    },
-];
-
-// ─── Main Page ────────────────────────────────────────────────────────────────
+ 
+import { STATUS_FILTERS, CloseIcon } from "../../components/client/applications/applicationsConstants";
+import { Toast, Skeleton, Pagination } from "../../components/client/applications/ApplicationsUI";
+import ApplicationCard from "../../components/client/applications/ApplicationCard";
+ 
 export default function MyApplications() {
   const [apps,          setApps]          = useState([]);
   const [loading,       setLoading]       = useState(true);
@@ -347,10 +15,10 @@ export default function MyApplications() {
   const [allCounts,     setAllCounts]     = useState({ PENDING: 0, APPROVED: 0, total: 0 });
   const [toast,         setToast]         = useState(null);
   const [statusFilter,  setStatusFilter]  = useState("");
-
+ 
   const notify = useCallback((msg, type = "success") =>
     setToast({ msg, type, key: Date.now() }), []);
-
+ 
   const loadApps = useCallback(async (pg = 0, status = statusFilter) => {
     setLoading(true);
     try {
@@ -363,12 +31,12 @@ export default function MyApplications() {
       setTotalElements(data.totalElements || 0);
       setPage(pg);
     } catch {
-      notify("Gabim gjatë ngarkimit të aplikimeve", "error");
+      notify("Error loading applications", "error");
     } finally {
       setLoading(false);
     }
   }, [notify, statusFilter]);
-
+ 
   const loadCounts = useCallback(async () => {
     try {
       const [totalRes, pendingRes, approvedRes] = await Promise.all([
@@ -383,42 +51,39 @@ export default function MyApplications() {
       });
     } catch {}
   }, []);
-
+ 
   useEffect(() => { loadApps(0, statusFilter); }, [statusFilter]); // eslint-disable-line
   useEffect(() => { loadCounts(); }, [loadCounts]);
-
-  const handleCancel = async (appId) => {
+ 
+  const handleCancel = async appId => {
     try {
       await api.patch(`/api/rentals/applications/${appId}/cancel`);
-      notify("Aplikimi u anulua me sukses");
+      notify("Application canceled successfully");
       loadApps(page, statusFilter);
       loadCounts();
     } catch (err) {
-      notify(err.response?.data?.message || "Gabim gjatë anulimit", "error");
+      notify(err.response?.data?.message || "Error occurred while canceling the application", "error");
     }
   };
-
+ 
   return (
     <MainLayout role="client">
-      {/* ── Exact same outer wrapper as BrowseProperties ── */}
       <div style={{ background: "#f5f2eb", minHeight: "100vh", fontFamily: "'Georgia', serif" }}>
-
-        {/* ── Hero — same gradient, same padding ── */}
+ 
+        {/* Hero */}
         <div style={{ background: "linear-gradient(135deg, #5a5f3a 0%, #3d4228 100%)", padding: "48px 32px 40px", textAlign: "center" }}>
           <h1 style={{ margin: "0 0 8px", fontSize: "32px", fontWeight: 800, color: "#fff", letterSpacing: "-0.5px" }}>
-            Aplikimet e Mia
+            My applications
           </h1>
           <p style={{ margin: "0 0 24px", color: "#c8ccaa", fontSize: "15px" }}>
-            Shiko dhe menaxho aplikimet tuaja për qira
+            View and manage your rental applications
           </p>
-
-          {/* Stat pills — same glass style as BrowseProperties */}
           {allCounts.total > 0 && (
             <div style={{ display: "flex", gap: "10px", maxWidth: "480px", margin: "0 auto", justifyContent: "center", flexWrap: "wrap" }}>
               {[
-                { label: "Gjithsej",  value: allCounts.total,    color: "#c8ccaa" },
-                { label: "Në pritje", value: allCounts.PENDING,  color: "#c9a84c" },
-                { label: "Aprovuar",  value: allCounts.APPROVED, color: "#a3c9b0" },
+                { label: "Total",  value: allCounts.total,    color: "#c8ccaa" },
+                { label: "Pending", value: allCounts.PENDING,  color: "#c9a84c" },
+                { label: "Approved",  value: allCounts.APPROVED, color: "#a3c9b0" },
               ].map(stat => (
                 <div key={stat.label} style={{ background: "rgba(255,255,255,0.13)", backdropFilter: "blur(6px)", borderRadius: "10px", padding: "10px 20px", border: "1px solid rgba(255,255,255,0.18)" }}>
                   <div style={{ fontSize: "24px", fontWeight: 900, color: stat.color, lineHeight: 1 }}>{stat.value}</div>
@@ -428,22 +93,20 @@ export default function MyApplications() {
             </div>
           )}
         </div>
-
-        {/* ── Body — same padding & maxWidth as BrowseProperties ── */}
+ 
+        {/* Body */}
         <div style={{ padding: "28px 24px", maxWidth: "1400px", margin: "0 auto" }}>
-
-          {/* Toolbar row — mirrors BrowseProperties count + filter row */}
+ 
+          {/* Toolbar */}
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "18px", flexWrap: "wrap", gap: "10px" }}>
-
-            {/* Left: count + active-filter chip */}
             <div style={{ display: "flex", alignItems: "center", gap: "10px", flexWrap: "wrap" }}>
               <span style={{ color: "#8a8469", fontSize: "13.5px" }}>
-                {loading ? "Duke ngarkuar…" : `${totalElements} aplikim${totalElements !== 1 ? "e" : ""} gjithsej`}
+                {loading ? "Loading…" : `${totalElements} application${totalElements !== 1 ? "s" : ""} total`}
               </span>
               {statusFilter && (
                 <button onClick={() => setStatusFilter("")}
                   style={{ display: "flex", alignItems: "center", gap: "5px", background: "#fff0f0", color: "#c0392b", border: "1px solid #f5c6c6", borderRadius: "8px", padding: "5px 12px", fontSize: "12.5px", cursor: "pointer", fontFamily: "inherit" }}>
-                  Pastro filtrin <CloseIcon />
+                  Clear filter <CloseIcon />
                 </button>
               )}
               {statusFilter && (
@@ -452,8 +115,6 @@ export default function MyApplications() {
                 </span>
               )}
             </div>
-
-            {/* Right: filter pills — same style as grid/list toggle in BrowseProperties */}
             <div style={{ display: "flex", gap: "4px", flexWrap: "wrap" }}>
               {STATUS_FILTERS.map(f => (
                 <button key={f.value} onClick={() => setStatusFilter(f.value)}
@@ -463,28 +124,22 @@ export default function MyApplications() {
               ))}
             </div>
           </div>
-
-          {/* Empty state */}
+ 
+          {/* Empty */}
           {!loading && apps.length === 0 && (
             <div style={{ textAlign: "center", padding: "64px 32px", color: "#8a8469" }}>
               <div style={{ fontSize: "48px", marginBottom: "12px" }}>📭</div>
               <h3 style={{ color: "#5a5f3a", margin: "0 0 8px" }}>
-                {statusFilter ? "Nuk ka aplikime me këtë status" : "Nuk keni dërguar aplikime ende"}
+                {statusFilter ? "No applications found with the selected status." : "You haven't submitted any applications yet."}
               </h3>
               <p style={{ margin: "0 0 16px" }}>
-                {statusFilter ? "Provoni të ndryshoni filtrin." : "Shikoni pronat dhe aplikoni për qira."}
+                {statusFilter ? "Try changing the filter." : "Browse properties and apply for rentals."}
               </p>
-              {statusFilter && (
-                <button onClick={() => setStatusFilter("")}
-                  style={{ ...S.applyBtn, width: "auto", padding: "10px 24px" }}>
-                  Shfaq të gjitha
-                </button>
-              )}
             </div>
           )}
-
+ 
           {loading && <Skeleton />}
-
+ 
           {!loading && apps.length > 0 && (
             <>
               <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
@@ -497,36 +152,16 @@ export default function MyApplications() {
           )}
         </div>
       </div>
-
+ 
       {toast && <Toast key={toast.key} msg={toast.msg} type={toast.type} onDone={() => setToast(null)} />}
-
+ 
       <style>{`
         @keyframes pulse         { 0%,100%{opacity:.5} 50%{opacity:.9} }
         @keyframes fadeInOverlay { from{opacity:0} to{opacity:1} }
         @keyframes slideUpModal  { from{transform:translateY(24px);opacity:0} to{transform:translateY(0);opacity:1} }
-        @keyframes fadeUp        { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
         @keyframes spin          { to{transform:rotate(360deg)} }
       `}</style>
     </MainLayout>
   );
 }
-
-// ─── Styles — same S object as BrowseProperties ───────────────────────────────
-const S = {
-  applyBtn: {
-    width: "100%", padding: "11px", background: "#5a5f3a", color: "#fff",
-    border: "none", borderRadius: "10px", fontSize: "14px", fontWeight: 700,
-    cursor: "pointer", fontFamily: "'Georgia', serif",
-  },
-  pageBtn: (active, disabled) => ({
-    padding: "7px 13px", borderRadius: "8px", border: "1.5px solid",
-    borderColor: active ? "#5a5f3a" : "#d9d4c7",
-    background:  active ? "#5a5f3a" : "#fff",
-    color: active ? "#fff" : disabled ? "#c5bfaf" : "#5a5f3a",
-    cursor: disabled ? "not-allowed" : "pointer",
-    fontSize: "13px", fontWeight: active ? 700 : 400,
-    fontFamily: "inherit", transition: "all 0.15s",
-    display: "flex", alignItems: "center", justifyContent: "center",
-    minWidth: "36px", minHeight: "36px",
-  }),
-};
+ 

--- a/src/pages/client/MySaleContracts.jsx
+++ b/src/pages/client/MySaleContracts.jsx
@@ -3,318 +3,23 @@ import MainLayout from "../../components/layout/Layout";
 import { AuthContext } from "../../context/AuthProvider";
 import api from "../../api/axios";
  
-const CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=DM+Sans:wght@300;400;500;600&display=swap');
-  .msc * { box-sizing: border-box; }
-  .msc { font-family: 'DM Sans', system-ui, sans-serif; background: #f2ede4; min-height: 100vh; }
-  .msc-card { transition: transform 0.22s cubic-bezier(0.25,0.46,0.45,0.94), box-shadow 0.22s ease; }
-  .msc-card:hover { transform: translateY(-4px); box-shadow: 0 20px 48px rgba(20,16,10,0.14) !important; }
-  .msc-btn { transition: all 0.15s ease; }
-  .msc-btn:hover:not(:disabled) { opacity: 0.86; transform: translateY(-1px); }
-  @keyframes msc-scale-in { from{opacity:0;transform:scale(0.95) translateY(10px)} to{opacity:1;transform:scale(1) translateY(0)} }
-  @keyframes msc-spin { to{transform:rotate(360deg)} }
-  @keyframes msc-pulse { 0%,100%{opacity:.38} 50%{opacity:.82} }
-  @keyframes msc-toast { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
-  @keyframes msc-glow { 0%,100%{opacity:0.07} 50%{opacity:0.14} }
-  @keyframes msc-card-in { from{opacity:0;transform:translateY(16px)} to{opacity:1;transform:translateY(0)} }
-`;
- 
-const fmtMoney = (v, cur = "EUR") =>
-  v != null ? new Intl.NumberFormat("de-DE", { style: "currency", currency: cur, maximumFractionDigits: 0 }).format(Number(v)) : "—";
-const fmtDate = (d) =>
-  d ? new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" }) : "—";
-const daysUntil = (d) => {
-  if (!d) return null;
-  return Math.ceil((new Date(d) - new Date()) / 86400000);
-};
- 
-const STATUS_CFG = {
-  PENDING:           { bg: "rgba(201,184,122,0.10)", color: "#a8923e", border: "rgba(201,184,122,0.28)", label: "Pending",           icon: "⏳", strip: "#c9b87a"  },
-  PENDING_SIGNATURE: { bg: "rgba(201,184,122,0.10)", color: "#a8923e", border: "rgba(201,184,122,0.28)", label: "Pending Signature", icon: "✍️", strip: "#c9b87a"  },
-  ACTIVE:            { bg: "rgba(126,184,164,0.12)", color: "#2a6049", border: "rgba(126,184,164,0.28)", label: "Active",            icon: "✅", strip: "#7eb8a4"  },
-  COMPLETED:         { bg: "rgba(126,184,164,0.12)", color: "#2a6049", border: "rgba(126,184,164,0.28)", label: "Completed",         icon: "🏆", strip: "#5aaa80"  },
-  CANCELLED:         { bg: "rgba(160,153,126,0.10)", color: "#6b6248", border: "rgba(160,153,126,0.20)", label: "Cancelled",         icon: "🚫", strip: "#9a8c6e"  },
-};
-const getStatus = (s) => STATUS_CFG[s] || { bg: "#f0ece3", color: "#6b6248", border: "#e0d8c8", label: s, icon: "📄", strip: "#b0a890" };
- 
-function Toast({ msg, type = "success", onDone }) {
-  useEffect(() => { const t = setTimeout(onDone, 3200); return () => clearTimeout(t); }, [onDone]);
-  return (
-    <div style={{ position: "fixed", bottom: 26, right: 26, zIndex: 9999, background: "#1a1714", color: type === "error" ? "#f09090" : "#90c8a8", padding: "11px 18px", borderRadius: 12, fontSize: 13, boxShadow: "0 10px 36px rgba(0,0,0,0.32)", border: `1px solid ${type === "error" ? "rgba(240,128,128,0.15)" : "rgba(144,200,168,0.15)"}`, maxWidth: 320, fontFamily: "'DM Sans',sans-serif", animation: "msc-toast 0.2s ease", display: "flex", alignItems: "center", gap: 8 }}>
-      <span style={{ fontSize: 14 }}>{type === "error" ? "⚠️" : "✅"}</span>{msg}
-    </div>
-  );
-}
- 
-function Skeleton() {
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      {Array.from({ length: 3 }).map((_, i) => (
-        <div key={i} style={{ background: "linear-gradient(90deg,#ede9df 25%,#e4ddd0 50%,#ede9df 75%)", backgroundSize: "800px 100%", borderRadius: 14, height: 160, animation: "msc-pulse 1.6s ease-in-out infinite" }} />
-      ))}
-    </div>
-  );
-}
- 
-const PGB = (active, disabled) => ({ padding: "7px 13px", borderRadius: 9, border: `1.5px solid ${active ? "#1a1714" : "#e4ddd0"}`, background: active ? "#1a1714" : "transparent", color: active ? "#f5f0e8" : disabled ? "#d4ccbe" : "#6b6248", cursor: disabled ? "not-allowed" : "pointer", fontSize: 13, fontWeight: active ? 600 : 400, fontFamily: "'DM Sans',sans-serif", opacity: disabled ? 0.5 : 1, transition: "all 0.14s" });
- 
-function Pagination({ page, totalPages, onChange }) {
-  if (totalPages <= 1) return null;
-  const pages = Array.from({ length: totalPages }, (_, i) => i);
-  const visible = pages.filter(p => p === 0 || p === totalPages - 1 || Math.abs(p - page) <= 1);
-  return (
-    <div style={{ display: "flex", justifyContent: "center", gap: 4, marginTop: 36, flexWrap: "wrap" }}>
-      <button disabled={page === 0} onClick={() => onChange(page - 1)} style={PGB(false, page === 0)}>‹</button>
-      {visible.map((p, i) => {
-        const gap = visible[i - 1] != null && p - visible[i - 1] > 1;
-        return (<span key={p} style={{ display: "flex", gap: 4 }}>{gap && <span style={{ padding: "7px 4px", color: "#b0a890", fontSize: 13 }}>…</span>}<button onClick={() => onChange(p)} style={PGB(p === page, false)}>{p + 1}</button></span>);
-      })}
-      <button disabled={page === totalPages - 1} onClick={() => onChange(page + 1)} style={PGB(false, page === totalPages - 1)}>›</button>
-    </div>
-  );
-}
- 
-// ─── Detail Modal — X button fix ──────────────────────────────────────────────
-function ContractDetailModal({ contract: c, onClose, onViewPayments }) {
-  const st = getStatus(c.status);
-  const days = daysUntil(c.handover_date);
- 
-  useEffect(() => {
-    const h = (e) => e.key === "Escape" && onClose();
-    window.addEventListener("keydown", h);
-    document.body.style.overflow = "hidden";
-    return () => { window.removeEventListener("keydown", h); document.body.style.overflow = ""; };
-  }, [onClose]);
- 
-  return (
-    <div onClick={(e) => e.target === e.currentTarget && onClose()} style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(8,6,4,0.84)", backdropFilter: "blur(14px)", display: "flex", alignItems: "center", justifyContent: "center", padding: 20, fontFamily: "'DM Sans',sans-serif" }}>
-      <div style={{ width: "100%", maxWidth: 560, background: "#faf7f2", borderRadius: 18, boxShadow: "0 44px 100px rgba(0,0,0,0.55)", maxHeight: "90vh", overflowY: "auto", animation: "msc-scale-in 0.24s ease" }}>
- 
-        {/* ── Header — X button nu është absolutë mbi badge ── */}
-        <div style={{ background: "linear-gradient(160deg,#141210 0%,#1e1a14 45%,#241e16 100%)", padding: "20px 24px 18px", borderRadius: "18px 18px 0 0", position: "relative" }}>
-          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: 2, background: "linear-gradient(90deg,transparent,#c9b87a 30%,#c9b87a 70%,transparent)", borderRadius: "18px 18px 0 0" }} />
- 
-          {/* Row 1: label + X */}
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
-            <p style={{ fontSize: 10, fontWeight: 600, color: "#c9b87a", textTransform: "uppercase", letterSpacing: "1.2px", margin: 0 }}>Sale Contract</p>
-            {/* X button këtu — larg badge-it */}
-            <button onClick={onClose} style={{ background: "rgba(245,240,232,0.08)", border: "1px solid rgba(245,240,232,0.14)", borderRadius: 8, width: 30, height: 30, cursor: "pointer", color: "rgba(245,240,232,0.65)", fontSize: 16, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>×</button>
-          </div>
- 
-          {/* Row 2: title + badge — nuk mbivendosen me X */}
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12 }}>
-            <h2 style={{ fontFamily: "'Cormorant Garamond',Georgia,serif", fontSize: 22, fontWeight: 700, color: "#f5f0e8", margin: 0 }}>
-              Contract #{c.id}
-            </h2>
-            <span style={{ background: st.bg, color: st.color, border: `1px solid ${st.border}`, padding: "5px 14px", borderRadius: 999, fontSize: 11, fontWeight: 700, flexShrink: 0 }}>
-              {st.icon} {st.label}
-            </span>
-          </div>
-        </div>
- 
-        <div style={{ padding: "22px 24px" }}>
-          {/* Key figures */}
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 20 }}>
-            {[
-              { label: "Sale Price",    value: fmtMoney(c.sale_price, c.currency), accent: true },
-              { label: "Property",      value: `#${c.property_id}` },
-              { label: "Contract Date", value: fmtDate(c.contract_date) },
-              { label: "Handover Date", value: fmtDate(c.handover_date) },
-            ].map(({ label, value, accent }) => (
-              <div key={label} style={{ background: accent ? "rgba(201,184,122,0.07)" : "#fff", border: `1.5px solid ${accent ? "rgba(201,184,122,0.22)" : "#e8e2d6"}`, borderRadius: 12, padding: "13px 16px" }}>
-                <p style={{ fontSize: 9.5, fontWeight: 600, color: "#b0a890", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 5 }}>{label}</p>
-                <p style={{ fontSize: 17, fontWeight: 700, color: accent ? "#c9b87a" : "#1a1714", margin: 0, fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{value}</p>
-              </div>
-            ))}
-          </div>
- 
-          {/* Handover countdown */}
-          {days !== null && c.status !== "COMPLETED" && c.status !== "CANCELLED" && (
-            <div style={{ background: days < 0 ? "rgba(212,133,90,0.08)" : days <= 7 ? "rgba(201,184,122,0.08)" : "rgba(126,184,164,0.08)", border: `1.5px solid ${days < 0 ? "rgba(212,133,90,0.25)" : days <= 7 ? "rgba(201,184,122,0.25)" : "rgba(126,184,164,0.25)"}`, borderRadius: 12, padding: "12px 16px", marginBottom: 16, fontSize: 13, color: days < 0 ? "#d4855a" : days <= 7 ? "#c9b87a" : "#2a6049", display: "flex", alignItems: "center", gap: 8 }}>
-              {days < 0 ? "⚠️" : days <= 7 ? "🕐" : "📅"}
-              {days < 0 ? `Handover was ${Math.abs(days)} day${Math.abs(days) !== 1 ? "s" : ""} ago` : days === 0 ? "Handover is today!" : `Handover in ${days} day${days !== 1 ? "s" : ""}`}
-            </div>
-          )}
- 
-          {c.status === "COMPLETED" && (
-            <div style={{ background: "rgba(126,184,164,0.08)", border: "1.5px solid rgba(126,184,164,0.22)", borderRadius: 12, padding: "12px 16px", marginBottom: 16, fontSize: 13, color: "#2a6049", display: "flex", alignItems: "center", gap: 8 }}>
-              🎉 Congratulations! This property purchase has been completed.
-            </div>
-          )}
- 
-          {c.contract_file_url && (
-            <div style={{ marginBottom: 16 }}>
-              <a href={c.contract_file_url} target="_blank" rel="noreferrer" style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px", background: "#fff", border: "1.5px solid #e8e2d6", borderRadius: 10, color: "#1a1714", textDecoration: "none", fontSize: 13 }}>
-                📎 <span>View Contract Document</span>
-                <span style={{ marginLeft: "auto", fontSize: 11, color: "#9a8c6e" }}>Open ↗</span>
-              </a>
-            </div>
-          )}
- 
-          <div style={{ display: "flex", gap: 8, paddingTop: 16, borderTop: "1.5px solid #e8e2d6" }}>
-            <button onClick={() => onViewPayments(c)} className="msc-btn" style={{ flex: 1, padding: "10px 16px", borderRadius: 10, background: "linear-gradient(135deg,#c9b87a,#b0983e)", color: "#1a1714", border: "none", fontSize: 13.5, fontWeight: 700, cursor: "pointer", fontFamily: "'DM Sans',sans-serif", display: "flex", alignItems: "center", justifyContent: "center", gap: 7 }}>
-              💳 View Payments
-            </button>
-            <button onClick={onClose} className="msc-btn" style={{ padding: "10px 18px", borderRadius: 10, border: "1.5px solid #e4ddd0", background: "transparent", color: "#6b6248", fontWeight: 500, fontSize: 13, cursor: "pointer", fontFamily: "'DM Sans',sans-serif" }}>
-              Close
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
- 
-function ContractCard({ contract: c, idx, onDetail, onPayments }) {
-  const st = getStatus(c.status);
-  const days = daysUntil(c.handover_date);
-  return (
-    <div className="msc-card" style={{ background: "#fff", borderRadius: 14, border: "1.5px solid #ece6da", overflow: "hidden", boxShadow: "0 2px 16px rgba(20,16,10,0.07)", animation: `msc-card-in 0.36s ease ${Math.min(idx * 0.06, 0.4)}s both` }}>
-      <div style={{ height: 4, background: st.strip }} />
-      <div style={{ padding: "18px 22px" }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, marginBottom: 14, flexWrap: "wrap" }}>
-          <div>
-            <p style={{ fontSize: 10, fontWeight: 600, color: "#b0a890", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 4 }}>Sale Contract #{c.id} · Property #{c.property_id}</p>
-            <p style={{ fontSize: 24, fontWeight: 700, color: "#1a1714", margin: 0, fontFamily: "'Cormorant Garamond',Georgia,serif", letterSpacing: "-0.3px" }}>{fmtMoney(c.sale_price, c.currency)}</p>
-          </div>
-          <span style={{ background: st.bg, color: st.color, border: `1px solid ${st.border}`, padding: "4px 13px", borderRadius: 999, fontSize: 10.5, fontWeight: 700, flexShrink: 0, display: "flex", alignItems: "center", gap: 5 }}>{st.icon} {st.label}</span>
-        </div>
-        <div style={{ display: "flex", gap: 20, flexWrap: "wrap", marginBottom: 14 }}>
-          {[{ label: "Contract Date", value: fmtDate(c.contract_date) }, { label: "Handover Date", value: fmtDate(c.handover_date) }].map(({ label, value }) => (
-            <div key={label}>
-              <p style={{ fontSize: 10, color: "#b0a890", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.7px", marginBottom: 3 }}>{label}</p>
-              <p style={{ fontSize: 13.5, color: "#4a4438", margin: 0, fontWeight: 500 }}>{value}</p>
-            </div>
-          ))}
-          {days !== null && c.status !== "COMPLETED" && c.status !== "CANCELLED" && (
-            <div style={{ marginLeft: "auto" }}>
-              <span style={{ fontSize: 11.5, fontWeight: 600, color: days < 0 ? "#d4855a" : days <= 7 ? "#c9b87a" : "#2a6049", background: days < 0 ? "rgba(212,133,90,0.08)" : days <= 7 ? "rgba(201,184,122,0.08)" : "rgba(126,184,164,0.08)", border: `1px solid ${days < 0 ? "rgba(212,133,90,0.22)" : days <= 7 ? "rgba(201,184,122,0.22)" : "rgba(126,184,164,0.22)"}`, padding: "3px 10px", borderRadius: 999 }}>
-                {days < 0 ? `${Math.abs(days)}d overdue` : days === 0 ? "Today" : `${days}d to handover`}
-              </span>
-            </div>
-          )}
-        </div>
-        {c.status === "COMPLETED" && (
-          <div style={{ background: "rgba(126,184,164,0.08)", border: "1.5px solid rgba(126,184,164,0.22)", borderRadius: 10, padding: "10px 14px", marginBottom: 14, fontSize: 13, color: "#2a6049", display: "flex", alignItems: "center", gap: 8 }}>
-            🎉 Property purchase completed successfully.
-          </div>
-        )}
-        <div style={{ display: "flex", gap: 8, paddingTop: 12, borderTop: "1.5px solid #f0ece3" }}>
-          <button onClick={() => onDetail(c)} className="msc-btn" style={{ flex: 1, padding: "8px 14px", borderRadius: 10, background: "#f0ece3", color: "#4a4438", border: "1.5px solid #e8e2d6", fontSize: 12.5, fontWeight: 500, cursor: "pointer", fontFamily: "'DM Sans',sans-serif", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>📄 Details</button>
-          <button onClick={() => onPayments(c)} className="msc-btn" style={{ flex: 1, padding: "8px 14px", borderRadius: 10, background: "#1a1714", color: "#f5f0e8", border: "none", fontSize: 12.5, fontWeight: 600, cursor: "pointer", fontFamily: "'DM Sans',sans-serif", display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>💳 Payments</button>
-        </div>
-      </div>
-    </div>
-  );
-}
- 
-function PaymentsQuickModal({ contract: c, onClose, notify }) {
-  const [payments, setPayments] = useState([]);
-  const [summary, setSummary] = useState(null);
-  const [loading, setLoading] = useState(true);
- 
-  useEffect(() => {
-    const h = (e) => e.key === "Escape" && onClose();
-    window.addEventListener("keydown", h);
-    document.body.style.overflow = "hidden";
-    return () => { window.removeEventListener("keydown", h); document.body.style.overflow = ""; };
-  }, [onClose]);
- 
-  useEffect(() => {
-    (async () => {
-      setLoading(true);
-      try {
-        const [listRes, sumRes] = await Promise.all([
-          api.get(`/api/sales/payments/contract/${c.id}`),
-          api.get(`/api/sales/payments/contract/${c.id}/summary`),
-        ]);
-        setPayments(listRes.data || []);
-        setSummary(sumRes.data);
-      } catch { notify("Failed to load payments", "error"); }
-      finally { setLoading(false); }
-    })();
-  }, [c.id, notify]);
- 
-  const TYPE_COLORS = {
-    FULL: { bg: "rgba(201,184,122,0.12)", color: "#8a7230" }, DEPOSIT: { bg: "rgba(126,184,164,0.12)", color: "#2a6049" },
-    INSTALLMENT: { bg: "#f0ece3", color: "#6b6248" }, COMMISSION: { bg: "rgba(126,184,164,0.12)", color: "#2a6049" },
-    AGENT_COMMISSION: { bg: "rgba(201,184,122,0.12)", color: "#8a6430" }, CLIENT_BONUS: { bg: "rgba(164,176,126,0.12)", color: "#4a6030" },
-  };
-  const STATUS_BADGE = {
-    PENDING: { bg: "rgba(201,184,122,0.10)", color: "#a8923e" }, PAID: { bg: "rgba(126,184,164,0.12)", color: "#2a6049" },
-    FAILED: { bg: "rgba(212,133,90,0.10)", color: "#8b4013" }, REFUNDED: { bg: "rgba(160,153,126,0.10)", color: "#6b6248" },
-  };
- 
-  return (
-    <div onClick={(e) => e.target === e.currentTarget && onClose()} style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(8,6,4,0.84)", backdropFilter: "blur(14px)", display: "flex", alignItems: "center", justifyContent: "center", padding: 20, fontFamily: "'DM Sans',sans-serif" }}>
-      <div style={{ width: "100%", maxWidth: 640, background: "#faf7f2", borderRadius: 18, boxShadow: "0 44px 100px rgba(0,0,0,0.55)", maxHeight: "90vh", overflowY: "auto", animation: "msc-scale-in 0.24s ease" }}>
-        <div style={{ background: "linear-gradient(160deg,#141210 0%,#1e1a14 100%)", padding: "20px 24px 18px", borderRadius: "18px 18px 0 0", position: "relative" }}>
-          <div style={{ position: "absolute", top: 0, left: 0, right: 0, height: 2, background: "linear-gradient(90deg,transparent,#c9b87a 30%,#c9b87a 70%,transparent)", borderRadius: "18px 18px 0 0" }} />
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
-            <p style={{ fontSize: 10, fontWeight: 600, color: "#c9b87a", textTransform: "uppercase", letterSpacing: "1.2px", margin: 0 }}>Payments</p>
-            <button onClick={onClose} style={{ background: "rgba(245,240,232,0.08)", border: "1px solid rgba(245,240,232,0.14)", borderRadius: 8, width: 30, height: 30, cursor: "pointer", color: "rgba(245,240,232,0.65)", fontSize: 16, display: "flex", alignItems: "center", justifyContent: "center" }}>×</button>
-          </div>
-          <h2 style={{ fontFamily: "'Cormorant Garamond',Georgia,serif", fontSize: 19, fontWeight: 700, color: "#f5f0e8", margin: "0 0 12px" }}>
-            Contract #{c.id} · {fmtMoney(c.sale_price, c.currency)}
-          </h2>
-          {summary && (
-            <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
-              {[{ label: "Total", value: summary.total_payments, color: "#c9b87a" }, { label: "Paid", value: fmtMoney(summary.total_paid), color: "#7eb8a4" }].map(s => (
-                <div key={s.label}>
-                  <span style={{ fontSize: 9.5, color: "rgba(245,240,232,0.35)", fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.8px" }}>{s.label} </span>
-                  <span style={{ fontSize: 16, fontWeight: 700, color: s.color, fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{s.value}</span>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-        <div style={{ padding: "18px 24px" }}>
-          {loading && <div style={{ textAlign: "center", padding: 36, color: "#9a8c6e" }}><div style={{ width: 24, height: 24, margin: "0 auto 12px", border: "2px solid #e8e2d6", borderTop: "2px solid #c9b87a", borderRadius: "50%", animation: "msc-spin .8s linear infinite" }} /><p style={{ fontSize: 13 }}>Loading payments…</p></div>}
-          {!loading && payments.length === 0 && <div style={{ textAlign: "center", padding: "32px 16px", color: "#b0a890" }}><div style={{ fontSize: 36, marginBottom: 10 }}>💳</div><p style={{ fontSize: 14 }}>No payments found.</p></div>}
-          {!loading && payments.length > 0 && (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              {payments.map(p => {
-                const tc = TYPE_COLORS[p.payment_type] || { bg: "#f0ece3", color: "#6b6248" };
-                const sc = STATUS_BADGE[p.status] || { bg: "#f0ece3", color: "#6b6248" };
-                return (
-                  <div key={p.id} style={{ background: "#fff", border: "1.5px solid #e8e2d6", borderRadius: 11, padding: "13px 16px" }}>
-                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                        <span style={{ background: tc.bg, color: tc.color, padding: "2px 9px", borderRadius: 999, fontSize: 10.5, fontWeight: 600 }}>{p.payment_type}</span>
-                        <span style={{ fontSize: 16, fontWeight: 700, color: "#1a1714", fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{fmtMoney(p.amount, p.currency)}</span>
-                      </div>
-                      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                        {p.paid_date && <span style={{ fontSize: 12, color: "#9a8c6e" }}>{fmtDate(p.paid_date)}</span>}
-                        <span style={{ background: sc.bg, color: sc.color, padding: "2px 10px", borderRadius: 999, fontSize: 10.5, fontWeight: 600 }}>{p.status}</span>
-                      </div>
-                    </div>
-                    <p style={{ fontSize: 12, color: "#9a8c6e", margin: "6px 0 0" }}>
-                      → {p.recipient_name ? <><strong style={{ color: "#6b6248" }}>{p.recipient_name}</strong> ({p.recipient_type})</> : <span style={{ color: "#7eb8a4", fontWeight: 600 }}>Company</span>}
-                    </p>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
+import { CSS_CONTRACTS } from "../../components/client/salecontracts/saleConstants";
+import { Toast, Skeleton, Pagination } from "../../components/client/salecontracts/SaleContractsUI";
+import { ContractCard, ContractDetailModal, PaymentsQuickModal } from "../../components/client/salecontracts/ContractComponents";
  
 export default function MySaleContracts() {
   const { user } = useContext(AuthContext);
-  const [contracts, setContracts] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [page, setPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
-  const [totalElements, setTotalElements] = useState(0);
-  const [detailTarget, setDetailTarget] = useState(null);
+  const [contracts,      setContracts]      = useState([]);
+  const [loading,        setLoading]        = useState(true);
+  const [page,           setPage]           = useState(0);
+  const [totalPages,     setTotalPages]     = useState(0);
+  const [totalElements,  setTotalElements]  = useState(0);
+  const [detailTarget,   setDetailTarget]   = useState(null);
   const [paymentsTarget, setPaymentsTarget] = useState(null);
-  const [toast, setToast] = useState(null);
+  const [toast,          setToast]          = useState(null);
   const notify = useCallback((msg, type = "success") => setToast({ msg, type, key: Date.now() }), []);
  
-  const fetch = useCallback(async () => {
+  const fetchContracts = useCallback(async () => {
     if (!user?.id) return;
     setLoading(true);
     try {
@@ -326,14 +31,20 @@ export default function MySaleContracts() {
     finally { setLoading(false); }
   }, [user?.id, page, notify]);
  
-  useEffect(() => { fetch(); }, [fetch]);
+  useEffect(() => { fetchContracts(); }, [fetchContracts]);
  
-  const stats = { total: totalElements, completed: contracts.filter(c => c.status === "COMPLETED").length, pending: contracts.filter(c => ["PENDING", "PENDING_SIGNATURE"].includes(c.status)).length };
+  const stats = {
+    total:     totalElements,
+    completed: contracts.filter(c => c.status === "COMPLETED").length,
+    pending:   contracts.filter(c => ["PENDING", "PENDING_SIGNATURE"].includes(c.status)).length,
+  };
  
   return (
     <MainLayout role="client">
-      <style>{CSS}</style>
+      <style>{CSS_CONTRACTS}</style>
       <div className="msc">
+ 
+        {/* Hero */}
         <div style={{ background: "linear-gradient(160deg,#141210 0%,#1e1a14 45%,#241e16 100%)", minHeight: 300, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "40px 32px", position: "relative", overflow: "hidden" }}>
           <div style={{ position: "absolute", inset: 0, backgroundImage: "radial-gradient(rgba(255,255,255,0.018) 1px,transparent 1px)", backgroundSize: "22px 22px", pointerEvents: "none" }} />
           <div style={{ position: "absolute", top: "-60px", left: "10%", width: 280, height: 280, borderRadius: "50%", background: "radial-gradient(circle,rgba(201,184,122,0.07) 0%,transparent 70%)", pointerEvents: "none", animation: "msc-glow 4s ease-in-out infinite" }} />
@@ -359,9 +70,13 @@ export default function MySaleContracts() {
             )}
           </div>
         </div>
+ 
+        {/* Toolbar */}
         <div style={{ background: "#fff", borderBottom: "1.5px solid #e8e2d6", padding: "0 28px", height: 46, display: "flex", alignItems: "center", justifyContent: "space-between", fontFamily: "'DM Sans',sans-serif", position: "sticky", top: 0, zIndex: 100, boxShadow: "0 1px 10px rgba(20,16,10,0.05)" }}>
           <p style={{ margin: 0, fontSize: 12.5, color: "#9a8c6e" }}>{loading ? "Loading…" : `${totalElements} contract${totalElements !== 1 ? "s" : ""}`}</p>
         </div>
+ 
+        {/* Content */}
         <div style={{ padding: "20px 24px", maxWidth: 900, margin: "0 auto" }}>
           {loading && <Skeleton />}
           {!loading && contracts.length === 0 && (
@@ -375,15 +90,18 @@ export default function MySaleContracts() {
           {!loading && contracts.length > 0 && (
             <>
               <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                {contracts.map((c, i) => <ContractCard key={c.id} contract={c} idx={i} onDetail={setDetailTarget} onPayments={setPaymentsTarget} />)}
+                {contracts.map((c, i) => (
+                  <ContractCard key={c.id} contract={c} idx={i} onDetail={setDetailTarget} onPayments={setPaymentsTarget} />
+                ))}
               </div>
               <Pagination page={page} totalPages={totalPages} onChange={setPage} />
             </>
           )}
         </div>
       </div>
-      {detailTarget && <ContractDetailModal contract={detailTarget} onClose={() => setDetailTarget(null)} onViewPayments={(c) => { setDetailTarget(null); setPaymentsTarget(c); }} />}
-      {paymentsTarget && <PaymentsQuickModal contract={paymentsTarget} onClose={() => setPaymentsTarget(null)} notify={notify} />}
+ 
+      {detailTarget   && <ContractDetailModal contract={detailTarget}   onClose={() => setDetailTarget(null)}   onViewPayments={c => { setDetailTarget(null); setPaymentsTarget(c); }} />}
+      {paymentsTarget && <PaymentsQuickModal  contract={paymentsTarget} onClose={() => setPaymentsTarget(null)} notify={notify} />}
       {toast && <Toast key={toast.key} msg={toast.msg} type={toast.type} onDone={() => setToast(null)} />}
     </MainLayout>
   );

--- a/src/pages/client/MySalePayments.jsx
+++ b/src/pages/client/MySalePayments.jsx
@@ -3,130 +3,23 @@ import MainLayout from "../../components/layout/Layout";
 import { AuthContext } from "../../context/AuthProvider";
 import api from "../../api/axios";
  
-const CSS = `
-  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400&family=DM+Sans:wght@300;400;500;600&display=swap');
-  .msp * { box-sizing: border-box; }
-  .msp { font-family: 'DM Sans', system-ui, sans-serif; background: #f2ede4; min-height: 100vh; }
-  .msp-card { background: #fff; border-radius: 14px; border: 1.5px solid #ece6da; box-shadow: 0 2px 16px rgba(20,16,10,0.07); }
-  .msp-btn { transition: all 0.15s ease; }
-  .msp-btn:hover:not(:disabled) { opacity: 0.86; transform: translateY(-1px); }
-  @keyframes msp-spin   { to{transform:rotate(360deg)} }
-  @keyframes msp-pulse  { 0%,100%{opacity:.38} 50%{opacity:.82} }
-  @keyframes msp-toast  { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
-  @keyframes msp-glow   { 0%,100%{opacity:0.07} 50%{opacity:0.14} }
-  @keyframes msp-row-in { from{opacity:0;transform:translateY(8px)} to{opacity:1;transform:translateY(0)} }
-`;
+import {
+  CSS_PAYMENTS,
+  fmtMoney,
+  fmtDate,
+  isOverdue,
+} from "../../components/client/salecontracts/saleConstants.js";
  
-const fmtMoney = (v, cur = "EUR") =>
-  v != null ? new Intl.NumberFormat("de-DE", { style: "currency", currency: cur, maximumFractionDigits: 0 }).format(Number(v)) : "—";
-const fmtDate = (d) =>
-  d ? new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" }) : "—";
-const isOverdue = (p) => {
-  if (!p.due_date || p.status !== "PENDING") return false;
-  return new Date(p.due_date) < new Date();
-};
+import {
+  Toast,
+  Skeleton,
+} from "../../components/client/salecontracts/SaleContractsUI.jsx";
  
-const TYPE_COLORS = {
-  FULL:             { bg: "rgba(201,184,122,0.15)", color: "#7a6220",  border: "rgba(201,184,122,0.35)", label: "Full Payment"     },
-  DEPOSIT:          { bg: "rgba(126,184,164,0.15)", color: "#1e5040",  border: "rgba(126,184,164,0.35)", label: "Deposit"          },
-  INSTALLMENT:      { bg: "rgba(100,120,180,0.10)", color: "#3a4a8a",  border: "rgba(100,120,180,0.28)", label: "Installment"      },
-  COMMISSION:       { bg: "rgba(126,184,164,0.12)", color: "#2a6049",  border: "rgba(126,184,164,0.28)", label: "Commission"       },
-  AGENT_COMMISSION: { bg: "rgba(201,184,122,0.12)", color: "#8a6430",  border: "rgba(201,184,122,0.28)", label: "Agent Commission" },
-  CLIENT_BONUS:     { bg: "rgba(164,176,126,0.12)", color: "#4a6030",  border: "rgba(164,176,126,0.28)", label: "Client Bonus"     },
-};
- 
-const STATUS_CFG = {
-  PENDING:  { bg: "rgba(201,184,122,0.12)", color: "#8a7230", border: "rgba(201,184,122,0.35)", label: "Pending",  strip: "#c9b87a" },
-  PAID:     { bg: "rgba(126,184,164,0.14)", color: "#1e5040", border: "rgba(126,184,164,0.35)", label: "Paid",     strip: "#7eb8a4" },
-  FAILED:   { bg: "rgba(212,133,90,0.12)",  color: "#7a3010", border: "rgba(212,133,90,0.30)",  label: "Failed",   strip: "#d4855a" },
-  REFUNDED: { bg: "rgba(160,153,126,0.12)", color: "#5a5238", border: "rgba(160,153,126,0.28)", label: "Refunded", strip: "#9a8c6e" },
-};
-const getStatus = (s) => STATUS_CFG[s] || { bg: "#f0ece3", color: "#6b6248", border: "#e0d8c8", label: s, strip: "#b0a890" };
-const getType   = (t) => TYPE_COLORS[t]  || { bg: "#f0ece3", color: "#6b6248", border: "#e0d8c8", label: t || "—" };
- 
-function Toast({ msg, type = "success", onDone }) {
-  useEffect(() => { const t = setTimeout(onDone, 3200); return () => clearTimeout(t); }, [onDone]);
-  return (
-    <div style={{ position: "fixed", bottom: 26, right: 26, zIndex: 9999, background: "#1a1714", color: type === "error" ? "#f09090" : "#90c8a8", padding: "11px 18px", borderRadius: 12, fontSize: 13, boxShadow: "0 10px 36px rgba(0,0,0,0.32)", border: `1px solid ${type === "error" ? "rgba(240,128,128,0.15)" : "rgba(144,200,168,0.15)"}`, maxWidth: 320, fontFamily: "'DM Sans',sans-serif", animation: "msp-toast 0.2s ease", display: "flex", alignItems: "center", gap: 8 }}>
-      <span style={{ fontSize: 14 }}>{type === "error" ? "⚠️" : "✅"}</span>{msg}
-    </div>
-  );
-}
- 
-function Skeleton() {
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} style={{ background: "linear-gradient(90deg,#ede9df 25%,#e4ddd0 50%,#ede9df 75%)", backgroundSize: "800px 100%", borderRadius: 11, height: 80, animation: "msp-pulse 1.6s ease-in-out infinite" }} />
-      ))}
-    </div>
-  );
-}
- 
-function SectionLabel({ label, count, color, borderColor }) {
-  return (
-    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
-      <span style={{ fontSize: 11, fontWeight: 700, color, textTransform: "uppercase", letterSpacing: "0.9px" }}>{label}</span>
-      <span style={{ background: `${color}20`, color, border: `1.5px solid ${borderColor || color + "40"}`, borderRadius: 999, padding: "2px 10px", fontSize: 11, fontWeight: 700 }}>{count}</span>
-      <div style={{ flex: 1, height: 1, background: `${color}25` }} />
-    </div>
-  );
-}
- 
-function PaymentRow({ payment: p, idx }) {
-  const sc  = getStatus(p.status);
-  const tc  = getType(p.payment_type);
-  const odd = isOverdue(p);
- 
-  return (
-    <div style={{
-      background: odd ? "rgba(212,133,90,0.05)" : "#fff",
-      border: `1.5px solid ${odd ? "rgba(212,133,90,0.28)" : "#e8e2d6"}`,
-      borderRadius: 11, padding: "14px 18px",
-      animation: `msp-row-in 0.3s ease ${Math.min(idx * 0.04, 0.3)}s both`,
-    }}>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 10, flexWrap: "wrap", marginBottom: 8 }}>
-        {/* Left: type + amount */}
-        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-          <span style={{ background: tc.bg, color: tc.color, border: `1.5px solid ${tc.border}`, padding: "3px 11px", borderRadius: 999, fontSize: 11, fontWeight: 700 }}>
-            {tc.label}
-          </span>
-          <span style={{ fontSize: 19, fontWeight: 700, color: "#1a1714", fontFamily: "'Cormorant Garamond',Georgia,serif" }}>
-            {fmtMoney(p.amount, p.currency)}
-          </span>
-          {odd && <span style={{ fontSize: 11, color: "#d4855a", fontWeight: 700, background: "rgba(212,133,90,0.1)", border: "1px solid rgba(212,133,90,0.28)", padding: "2px 8px", borderRadius: 999 }}>⚠️ Overdue</span>}
-        </div>
-        {/* Right: date + status */}
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          {p.paid_date && <span style={{ fontSize: 12, color: "#9a8c6e" }}>Paid {fmtDate(p.paid_date)}</span>}
-          {!p.paid_date && p.due_date && <span style={{ fontSize: 12, color: odd ? "#d4855a" : "#9a8c6e", fontWeight: odd ? 600 : 400 }}>Due {fmtDate(p.due_date)}</span>}
-          <span style={{ background: sc.bg, color: sc.color, border: `1.5px solid ${sc.border}`, padding: "3px 11px", borderRadius: 999, fontSize: 11, fontWeight: 700 }}>
-            {sc.label}
-          </span>
-        </div>
-      </div>
-      {/* Recipient */}
-      <div style={{ fontSize: 12.5, color: "#9a8c6e", display: "flex", alignItems: "center", gap: 5 }}>
-        <span style={{ color: "#c9b87a" }}>→</span>
-        {p.recipient_name
-          ? <><strong style={{ color: "#6b6248" }}>{p.recipient_name}</strong> <span style={{ background: "#f0ece3", color: "#9a8c6e", padding: "1px 7px", borderRadius: 999, fontSize: 10.5, fontWeight: 600 }}>{p.recipient_type}</span></>
-          : <span style={{ color: "#2a6049", fontWeight: 600, background: "rgba(126,184,164,0.1)", border: "1px solid rgba(126,184,164,0.22)", padding: "1px 8px", borderRadius: 999, fontSize: 11 }}>🏢 Company</span>
-        }
-        {p.transaction_ref && <span style={{ marginLeft: 8, background: "#f0ece3", color: "#9a8c6e", padding: "1px 8px", borderRadius: 999, fontSize: 10.5 }}>Ref: {p.transaction_ref}</span>}
-      </div>
-    </div>
-  );
-}
- 
-function ContractTab({ contract: c, selected, onSelect }) {
-  const dotColor = c.status === "COMPLETED" ? "#7eb8a4" : c.status === "CANCELLED" ? "#9a8c6e" : "#c9b87a";
-  return (
-    <button onClick={() => onSelect(c.id)} style={{ padding: "9px 16px", borderRadius: 10, background: selected ? "#1a1714" : "#fff", color: selected ? "#f5f0e8" : "#4a4438", border: `1.5px solid ${selected ? "#1a1714" : "#e8e2d6"}`, cursor: "pointer", fontFamily: "'DM Sans',sans-serif", fontSize: 12.5, fontWeight: selected ? 600 : 400, transition: "all 0.15s", whiteSpace: "nowrap", display: "flex", alignItems: "center", gap: 7 }}>
-      <span style={{ width: 7, height: 7, borderRadius: "50%", background: dotColor, display: "inline-block", flexShrink: 0 }} />
-      #{c.id} — {fmtMoney(c.sale_price, c.currency)}
-    </button>
-  );
-}
+import {
+  SectionLabel,
+  PaymentRow,
+  ContractTab,
+} from "../../components/client/salecontracts/PaymentComponents.jsx";
  
 export default function MySalePayments() {
   const { user } = useContext(AuthContext);
@@ -175,19 +68,18 @@ export default function MySalePayments() {
   const paidPayments    = payments.filter(p => p.status === "PAID");
   const overduePayments = payments.filter(p => isOverdue(p));
   const pendingPayments = payments.filter(p => p.status === "PENDING" && !isOverdue(p));
-  const otherPayments   = payments.filter(p => !["PAID","PENDING","REFUNDED"].includes(p.status) && !isOverdue(p));
+  const otherPayments   = payments.filter(p => !["PAID", "PENDING", "REFUNDED"].includes(p.status) && !isOverdue(p));
   const totalPaid    = paidPayments.reduce((a, p) => a + Number(p.amount || 0), 0);
   const totalPending = [...pendingPayments, ...overduePayments].reduce((a, p) => a + Number(p.amount || 0), 0);
   const selectedContract = contracts.find(c => c.id === selectedId);
  
-  // Progress %
   const progressPct = selectedContract && selectedContract.sale_price > 0
     ? Math.min(100, Math.round((Number(summary?.total_paid || 0) / Number(selectedContract.sale_price)) * 100))
     : 0;
  
   return (
     <MainLayout role="client">
-      <style>{CSS}</style>
+      <style>{CSS_PAYMENTS}</style>
       <div className="msp">
  
         {/* ── Hero ── */}
@@ -207,10 +99,10 @@ export default function MySalePayments() {
             {selectedId && !loading && payments.length > 0 && (
               <div style={{ display: "flex", gap: 10, maxWidth: 560, margin: "0 auto", justifyContent: "center", flexWrap: "wrap" }}>
                 {[
-                  { label: "Total",       value: payments.length,         dot: "#c9b87a" },
-                  { label: "Paid",        value: fmtMoney(totalPaid),     dot: "#7eb8a4" },
-                  { label: "Outstanding", value: fmtMoney(totalPending),  dot: "#c9b87a" },
-                  { label: "Overdue",     value: overduePayments.length,  dot: "#d4855a" },
+                  { label: "Total",       value: payments.length,        dot: "#c9b87a" },
+                  { label: "Paid",        value: fmtMoney(totalPaid),    dot: "#7eb8a4" },
+                  { label: "Outstanding", value: fmtMoney(totalPending), dot: "#c9b87a" },
+                  { label: "Overdue",     value: overduePayments.length, dot: "#d4855a" },
                 ].map(s => (
                   <div key={s.label} style={{ background: "rgba(245,240,232,0.06)", backdropFilter: "blur(10px)", borderRadius: 12, padding: "10px 18px", border: "1px solid rgba(245,240,232,0.1)", display: "flex", flexDirection: "column", alignItems: "center", gap: 3 }}>
                     <span style={{ fontSize: 18, fontWeight: 700, color: s.dot, lineHeight: 1, fontFamily: "'Cormorant Garamond',Georgia,serif" }}>{s.value}</span>
@@ -245,7 +137,9 @@ export default function MySalePayments() {
               <div className="msp-card" style={{ padding: "18px 22px", marginBottom: 18, animation: "msp-row-in 0.3s ease both" }}>
                 <p style={{ fontSize: 9.5, fontWeight: 600, color: "#b0a890", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 12 }}>Select Purchase Contract</p>
                 <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                  {contracts.map(c => <ContractTab key={c.id} contract={c} selected={selectedId === c.id} onSelect={setSelectedId} />)}
+                  {contracts.map(c => (
+                    <ContractTab key={c.id} contract={c} selected={selectedId === c.id} onSelect={setSelectedId} />
+                  ))}
                 </div>
               </div>
  
@@ -256,14 +150,14 @@ export default function MySalePayments() {
                 </div>
               )}
  
-              {/* ── Stat cards — redesigned for better visibility ── */}
+              {/* ── Stat cards ── */}
               {selectedId && !loading && summary && payments.length > 0 && (
                 <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(150px,1fr))", gap: 12, marginBottom: 18 }}>
                   {[
-                    { label: "Total Payments", value: payments.length,       color: "#8a7230", bg: "#fdf8ee", border: "#e8d898", icon: "📋" },
+                    { label: "Total Payments", value: payments.length,                    color: "#8a7230", bg: "#fdf8ee", border: "#e8d898", icon: "📋" },
                     { label: "Total Paid",      value: fmtMoney(summary.total_paid || 0), color: "#1e5040", bg: "#edf7f2", border: "#9adbc0", icon: "✅" },
-                    { label: "Outstanding",     value: fmtMoney(totalPending), color: "#6b5820", bg: "#fdf6e3", border: "#d4b860", icon: "⏳" },
-                    { label: "Overdue",         value: overduePayments.length, color: overduePayments.length > 0 ? "#8b3010" : "#5a5238", bg: overduePayments.length > 0 ? "#fef0e8" : "#f5f2eb", border: overduePayments.length > 0 ? "#e89060" : "#d4ccb0", icon: overduePayments.length > 0 ? "🔴" : "✓" },
+                    { label: "Outstanding",     value: fmtMoney(totalPending),            color: "#6b5820", bg: "#fdf6e3", border: "#d4b860", icon: "⏳" },
+                    { label: "Overdue",         value: overduePayments.length,            color: overduePayments.length > 0 ? "#8b3010" : "#5a5238", bg: overduePayments.length > 0 ? "#fef0e8" : "#f5f2eb", border: overduePayments.length > 0 ? "#e89060" : "#d4ccb0", icon: overduePayments.length > 0 ? "🔴" : "✓" },
                   ].map(s => (
                     <div key={s.label} style={{ background: s.bg, borderRadius: 13, padding: "15px 18px", border: `2px solid ${s.border}`, display: "flex", flexDirection: "column", gap: 6 }}>
                       <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
@@ -276,7 +170,7 @@ export default function MySalePayments() {
                 </div>
               )}
  
-              {/* ── Progress bar — redesigned ── */}
+              {/* ── Progress bar ── */}
               {selectedContract && !loading && summary && (
                 <div className="msp-card" style={{ padding: "18px 22px", marginBottom: 18 }}>
                   <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 10 }}>
@@ -288,7 +182,6 @@ export default function MySalePayments() {
                       {fmtMoney(summary.total_paid || 0)} <span style={{ color: "#b0a890", fontWeight: 400, fontSize: 13 }}>of</span> {fmtMoney(selectedContract.sale_price, selectedContract.currency)}
                     </span>
                   </div>
-                  {/* Track */}
                   <div style={{ height: 12, background: "#e8e2d6", borderRadius: 999, overflow: "hidden", position: "relative" }}>
                     <div style={{ height: "100%", borderRadius: 999, width: `${progressPct}%`, background: progressPct >= 100 ? "linear-gradient(90deg,#5aaa80,#7eb8a4)" : "linear-gradient(90deg,#c9b87a,#e8d9a0)", transition: "width 0.7s ease", position: "relative" }}>
                       {progressPct > 8 && (
@@ -306,24 +199,64 @@ export default function MySalePayments() {
                 </div>
               )}
  
-              {/* Payments list */}
+              {/* ── Payments list ── */}
               <div className="msp-card" style={{ overflow: "hidden" }}>
                 <div style={{ padding: "16px 22px", borderBottom: "1.5px solid #ece6da", display: "flex", justifyContent: "space-between", alignItems: "center", background: "#faf7f2" }}>
                   <h2 style={{ margin: 0, fontSize: 15, fontWeight: 700, color: "#1a1714", fontFamily: "'Cormorant Garamond',Georgia,serif" }}>
                     {selectedId ? `Payments — Contract #${selectedId}` : "Select a contract"}
                   </h2>
-                  {!loading && payments.length > 0 && <span style={{ background: "rgba(201,184,122,0.12)", color: "#8a7230", border: "1.5px solid rgba(201,184,122,0.3)", padding: "3px 12px", borderRadius: 999, fontSize: 11.5, fontWeight: 700 }}>{payments.length} payments</span>}
+                  {!loading && payments.length > 0 && (
+                    <span style={{ background: "rgba(201,184,122,0.12)", color: "#8a7230", border: "1.5px solid rgba(201,184,122,0.3)", padding: "3px 12px", borderRadius: 999, fontSize: 11.5, fontWeight: 700 }}>{payments.length} payments</span>
+                  )}
                 </div>
                 <div style={{ padding: "18px 22px" }}>
-                  {!selectedId && <div style={{ textAlign: "center", padding: "56px 20px", color: "#b0a890" }}><div style={{ fontSize: 44, marginBottom: 12 }}>👆</div><p style={{ fontSize: 14, fontFamily: "'Cormorant Garamond',Georgia,serif", color: "#6b6340" }}>Select a contract above to view its payments.</p></div>}
+                  {!selectedId && (
+                    <div style={{ textAlign: "center", padding: "56px 20px", color: "#b0a890" }}>
+                      <div style={{ fontSize: 44, marginBottom: 12 }}>👆</div>
+                      <p style={{ fontSize: 14, fontFamily: "'Cormorant Garamond',Georgia,serif", color: "#6b6340" }}>Select a contract above to view its payments.</p>
+                    </div>
+                  )}
                   {selectedId && loading && <Skeleton />}
-                  {selectedId && !loading && payments.length === 0 && <div style={{ textAlign: "center", padding: "56px 20px", color: "#b0a890" }}><div style={{ fontSize: 44, marginBottom: 12 }}>💳</div><p style={{ fontSize: 14, fontFamily: "'Cormorant Garamond',Georgia,serif", color: "#6b6340" }}>No payments found for this contract.</p></div>}
+                  {selectedId && !loading && payments.length === 0 && (
+                    <div style={{ textAlign: "center", padding: "56px 20px", color: "#b0a890" }}>
+                      <div style={{ fontSize: 44, marginBottom: 12 }}>💳</div>
+                      <p style={{ fontSize: 14, fontFamily: "'Cormorant Garamond',Georgia,serif", color: "#6b6340" }}>No payments found for this contract.</p>
+                    </div>
+                  )}
                   {selectedId && !loading && payments.length > 0 && (
                     <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-                      {overduePayments.length > 0 && <div><SectionLabel label="⚠ Overdue" count={overduePayments.length} color="#c06030" borderColor="rgba(212,133,90,0.4)" /><div style={{ display: "flex", flexDirection: "column", gap: 8 }}>{overduePayments.map((p, i) => <PaymentRow key={p.id} payment={p} idx={i} />)}</div></div>}
-                      {pendingPayments.length > 0 && <div><SectionLabel label="Pending" count={pendingPayments.length} color="#8a7230" borderColor="rgba(201,184,122,0.4)" /><div style={{ display: "flex", flexDirection: "column", gap: 8 }}>{pendingPayments.map((p, i) => <PaymentRow key={p.id} payment={p} idx={i} />)}</div></div>}
-                      {paidPayments.length > 0 && <div><SectionLabel label="Paid" count={paidPayments.length} color="#1e5040" borderColor="rgba(126,184,164,0.4)" /><div style={{ display: "flex", flexDirection: "column", gap: 8 }}>{paidPayments.map((p, i) => <PaymentRow key={p.id} payment={p} idx={i} />)}</div></div>}
-                      {otherPayments.length > 0 && <div><SectionLabel label="Other" count={otherPayments.length} color="#6b6248" borderColor="rgba(160,153,126,0.4)" /><div style={{ display: "flex", flexDirection: "column", gap: 8 }}>{otherPayments.map((p, i) => <PaymentRow key={p.id} payment={p} idx={i} />)}</div></div>}
+                      {overduePayments.length > 0 && (
+                        <div>
+                          <SectionLabel label="⚠ Overdue" count={overduePayments.length} color="#c06030" borderColor="rgba(212,133,90,0.4)" />
+                          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                            {overduePayments.map((p, i) => <PaymentRow key={p.id} payment={p} idx={i} />)}
+                          </div>
+                        </div>
+                      )}
+                      {pendingPayments.length > 0 && (
+                        <div>
+                          <SectionLabel label="Pending" count={pendingPayments.length} color="#8a7230" borderColor="rgba(201,184,122,0.4)" />
+                          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                            {pendingPayments.map((p, i) => <PaymentRow key={p.id} payment={p} idx={i} />)}
+                          </div>
+                        </div>
+                      )}
+                      {paidPayments.length > 0 && (
+                        <div>
+                          <SectionLabel label="Paid" count={paidPayments.length} color="#1e5040" borderColor="rgba(126,184,164,0.4)" />
+                          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                            {paidPayments.map((p, i) => <PaymentRow key={p.id} payment={p} idx={i} />)}
+                          </div>
+                        </div>
+                      )}
+                      {otherPayments.length > 0 && (
+                        <div>
+                          <SectionLabel label="Other" count={otherPayments.length} color="#6b6248" borderColor="rgba(160,153,126,0.4)" />
+                          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                            {otherPayments.map((p, i) => <PaymentRow key={p.id} payment={p} idx={i} />)}
+                          </div>
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
Ky PR ndan 5 faqe monolitike të klientit në strukturë komponentale, identike me modelin AdminRentals.

Çfarë u ndryshua:
— ClientLeads: 7 skedarë (leadsConstants, LeadsIcons, LeadsUI, PropertyFields, CreateLeadModal, LeadDetailModal, LeadCard)
— ClientProfile: 4 skedarë (profileConstants, ProfileUI, ProfileSidebar, ProfileTabs)
— MyApplications: 4 skedarë (applicationsConstants, ApplicationsUI, ApplicationModals, ApplicationCard)
— MySaleContracts + MySalePayments: constants të përbashkët + ContractComponents + PaymentComponents

Çfarë nuk u ndryshua: asnjë ndryshim në logjikë, pamje, API calls, ose state management. Vetëm riorganizim i skedarëve.

Closes #181 